### PR TITLE
Add requirements section to manifest definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,6 +192,30 @@
 
 			</section>
 
+			<section id="manifest-requirements">
+				<h5>Requirements</h5>
+
+				<p>The following properties are REQUIRED in all implementations of the a <a>digital publication</a>
+					manifest:</p>
+
+				<ul>
+					<li>
+						<a href="#default-reading-order">default reading order</a>
+					</li>
+					<li>
+						<a href="#pub-title">title</a>
+					</li>
+				</ul>
+
+				<p class="note">These properties do not have to be serialized in the <a>authored manifest</a>. Refer to
+					each property's definition to determine how it is compiled into the <a>canonical manifest</a> from
+					other information.</p>
+
+				<p>The priority of all other <a href="#manifest-properties">properties</a> and <a href="#manifest-rel"
+						>resource relations</a> is OPTIONAL, but MAY be modified by implementations of the manifest
+					format.</p>
+			</section>
+
 			<section id="webidl">
 				<h3>Web IDL</h3>
 

--- a/index.html
+++ b/index.html
@@ -195,10 +195,15 @@
 			<section id="manifest-requirements">
 				<h5>Requirements</h5>
 
-				<p>The following properties are REQUIRED in all implementations of the a <a>digital publication</a>
-					manifest:</p>
+				<p>All implementations of the a <a>digital publication</a> manifest MUST set the following:</p>
 
 				<ul>
+					<li>
+						<a href="#manifest-context">context</a>
+					</li>
+					<li>
+						<a href="#publication-types">type</a>
+					</li>
 					<li>
 						<a href="#default-reading-order">default reading order</a>
 					</li>
@@ -207,9 +212,9 @@
 					</li>
 				</ul>
 
-				<p class="note">These properties do not have to be serialized in the <a>authored manifest</a>. Refer to
-					each property's definition to determine how it is compiled into the <a>canonical manifest</a> from
-					other information.</p>
+				<p class="note">Not all of these properties have to be serialized in the <a>authored manifest</a>. Refer
+					to each property's definition to determine if and how it is compiled into the <a>canonical
+						manifest</a> from other information.</p>
 
 				<p>The priority of all other <a href="#manifest-properties">properties</a> and <a href="#manifest-rel"
 						>resource relations</a> is OPTIONAL, but MAY be modified by implementations of the manifest
@@ -306,8 +311,8 @@ enum ProgressionDirection {
 				<h3>Manifest Contexts</h3>
 
 				<p>A <a>digital publication's</a>
-					<a>manifest</a> MUST start by setting the JSON-LD context [[!json-ld]]. The context has the
-					following two major components:</p>
+					<a>manifest</a> starts by setting the JSON-LD context [[!json-ld]]. The context has the following
+					two major components:</p>
 
 				<ul>
 					<li>the [[!schema.org]] context: <code>https://schema.org</code></li>
@@ -338,7 +343,7 @@ enum ProgressionDirection {
 				<h4>Publication Types</h4>
 
 				<p>A <a>digital publication's</a>
-					<a>manifest</a> MUST define its <dfn>Publication Type</dfn> using the <code
+					<a>manifest</a> defines its <dfn>Publication Type</dfn> using the <code
 						data-dfn-for="PublicationManifest"><dfn>type</dfn></code> term&#160;[[!json-ld]]. The type MAY
 					be mapped onto <a href="https://schema.org/CreativeWork"
 					><code>CreativeWork</code></a>&#160;[[!schema.org]].</p>


### PR DESCRIPTION
This PR is a start on addressing #5. It lists the two required properties (title and reading order) and indicates that all others are optional, but priority is also dictated by specific implementations.

Interestingly, the following is the minimum valid manifest, as the "required" properties are both compiled when not set:

```
{
    "@context" : ["https://schema.org", "https://www.w3.org/ns/wp-context"],
    "type"     : "CreativeWork"
}
```

I'm thinking it might be worth listing context and type as required properties, even though we didn't before, rather than assume them as part of a default configuration.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/18.html" title="Last updated on Aug 7, 2019, 8:01 PM UTC (4be22d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/18/c1c1d87...4be22d2.html" title="Last updated on Aug 7, 2019, 8:01 PM UTC (4be22d2)">Diff</a>