### PR TITLE
Make lack of type a warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -2580,10 +2580,9 @@ enum ProgressionDirection {
 							Publication Manifest, namely:</p>
 						<ul>
 							<li>the JSON-LD context is set as required in <a href="#manifest-context"></a>;</li>
-							<li>the Publication type is set as required in <a href="#publication-types"></a>; and</li>
 							<li>any extension requirements are set as defined in their respective specifications.</li>
 						</ul>
-						<p>If any of these requirements is not met, terminate the algorithm.</p>
+						<p>If any of these requirements are not met, terminate the algorithm.</p>
 					</li>
 
 					<li>Let <var>processed manifest</var> be the result of <a>post-processing a canonical manifest</a>
@@ -2975,6 +2974,8 @@ enum ProgressionDirection {
 					<li><p>Perform data cleanup operations on <var>manifest</var>, possibly removing data, as well as
 							raising warnings.</p>
 						<ol>
+							<li>Check whether the value of <var>manifest["type"]</var> is empty. If it is, set the value
+								to "<code>CreativeWork</code>" and issue a warning.</li>
 							<li>For all <var>term</var> that expect <a href="#value-object-entity">entities</a>, check
 								whether the value object <var>P</var> in <var>manifest[term]</var> has
 									<var>P["name"]</var> set. If not, remove <var>P</var> from <var>manifest[term]</var>
@@ -2987,8 +2988,8 @@ enum ProgressionDirection {
 							<li>For every object <var>P</var> of type <a>LinkedResource</a>, if the value of
 									<var>P["length"]</var> is set, check whether this value is a valid number. If the
 								check fails, issue a warning.</li>
-							<li>Check whether the value of <var>manifest["name"]</var> is not empty. If it is, generate
-								a value (see the <a href="#generate_title">separate note for details</a>) and issue a
+							<li>Check whether the value of <var>manifest["name"]</var> is empty. If it is, generate a
+								value (see the <a href="#generate_title">separate note for details</a>) and issue a
 								warning. </li>
 							<li>Check whether <var>manifest["datePublished"]</var> is a valid date or date-time,
 								per&#160;[[!iso8601]]. If the check fails, issue a warning. </li>


### PR DESCRIPTION
This PR fixes #25 by moving the check of `type` to the post-processing steps. If the value is not set, "CreativeWork" is used and a warning is issued.

(It also fixes a minor bug with the title where the wording suggests to issue a warning and generate a title when the value is non empty.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/27.html" title="Last updated on Aug 9, 2019, 2:19 PM UTC (27ea111)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/27/b733e29...27ea111.html" title="Last updated on Aug 9, 2019, 2:19 PM UTC (27ea111)">Diff</a>