### PR TITLE
Remove para about canonical identifier and preferred version

### DIFF
--- a/index.html
+++ b/index.html
@@ -870,15 +870,6 @@ enum ProgressionDirection {
 							</tbody>
 						</table>
 
-						<p>The canonical identifier SHOULD be a <a>URL</a> that resolves to the preferred version of the
-								<a>digital publication</a>. Using a URL provides a measure of permanence above and
-							beyond a digital publication's <a href="#address">address(es)</a>. If a digital publication
-							is permanently relocated to a new URL, for example, the canonical address provides a way of
-							discovering the new location (e.g., a <abbr title="Digital Object Identifier">DOI</abbr>
-							registry could be updated with the new URL, or a redirect could be added to the URL of the
-							canonical identifier). It is also intended to provide a means of identifying instances of
-							the same digital publication hosted at different URLs.</p>
-
 						<p class="note">Ensuring uniqueness of canonical identifiers is outside the scope of this
 							specification. The actual achievable uniqueness depends on such factors as the conventions
 							of the identifier scheme used and the degree of control over assignment of identifiers.</p>


### PR DESCRIPTION
This PR fixes #3 by removing the paragraph that recommends that the URL in the canonical identifier resolve the preferred version of the publication.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/28.html" title="Last updated on Aug 10, 2019, 10:13 PM UTC (2b08f50)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/28/8584f7e...2b08f50.html" title="Last updated on Aug 10, 2019, 10:13 PM UTC (2b08f50)">Diff</a>