### PR TITLE
'well-formed' bcp

### DIFF
--- a/index.html
+++ b/index.html
@@ -1378,7 +1378,7 @@ enum ProgressionDirection {
 								</tbody>
 							</table>
 
-							<p>The natural language MUST be a tag that conforms to&#160;[[!bcp47]], while the <dfn
+							<p>The natural language MUST be a well-formed in terms of &#160;[[!bcp47]], while the <dfn
 									data-lt="TextDirection">base language direction</dfn> MUST have one of the following
 								values:</p>
 


### PR DESCRIPTION
(MIni change.)

The official I18N review claims to prefer the usage of 'well-formed' when referring to conformance to bcp47. Changed this reference.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/37.html" title="Last updated on Aug 21, 2019, 7:55 AM UTC (2612b72)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/37/92c505c...2612b72.html" title="Last updated on Aug 21, 2019, 7:55 AM UTC (2612b72)">Diff</a>