### PR TITLE
Updates to canonicalization and processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,15 +90,19 @@
 			<section id="terminology">
 				<h3>Terminology</h3>
 
-				<p>This document uses terminology defined by the W3C Note "Publishing and Linking on the
-					Web"&#160;[[publishing-linking]], including, in particular, <a class="externalDFN"
-						href="https://www.w3.org/TR/publishing-linking/#dfn-user">user</a>, <a class="externalDFN"
-						href="https://www.w3.org/TR/publishing-linking/#dfn-user-agent">user agent</a>, <a
-						class="externalDFN" href="https://www.w3.org/TR/publishing-linking/#dfn-browser">browser</a>,
-					and <a class="externalDFN" href="https://www.w3.org/TR/publishing-linking/#dfn-address"
-					>address</a>.</p>
-
 				<dl>
+					<dt>
+						<dfn>Canonical Representation</dfn>
+					</dt>
+					<dd>
+						<p>The canonical representation of a manifest is the internal data structure created by user
+							agents when they <a href="#manifest-processing">process the manifest</a> and remove all
+							possible ambiguities and incorporate any missing values that can be inferred from another
+							source.</p>
+						<p>It is possible for the information expressed in the manifest to be the equivalent of the
+							canonical representation created by user agents if there are no ambiguities or missing
+							information.</p>
+					</dd>
 					<dt>
 						<dfn data-lt="digital publications|digital publication's">Digital Publication</dfn>
 					</dt>
@@ -133,55 +137,45 @@
 		<section id="manifest">
 			<h2>Publication Manifest</h2>
 
-			<section id="manifest-intro" class="informative">
+			<section id="manifest-intro">
 				<h3>Introduction</h3>
 
-				<p>A <a>digital publication</a> is described by its <a>manifest</a>, which provides a set of properties
-					expressed using the JSON-LD&#160;[[json-ld]] format (a variant of JSON&#160;[[ecma-404]] for linked
-					data).</p>
+				<section id="manifest-format" class="informative">
+					<h4>Manifest Format</h4>
 
-				<p>The manifest includes both descriptive properties about the publication, such as its title and
-					author, as well as information about the nature and structure of the publication.</p>
+					<p>A <a>digital publication</a> is described by its <a>manifest</a>, which provides a set of
+						properties expressed using a specific shape of JSON-LD&#160;[[json-ld]] format (a variant of
+						JSON&#160;[[ecma-404]] for linked data).</p>
 
-				<p>This section describes the construction requirements for manifests, and outlines the general set of
-					properties for use with them.</p>
-			</section>
+					<p>The manifest includes both descriptive properties about the publication, such as its title and
+						author, as well as information about the nature and structure of the publication.</p>
 
-			<section id="manifest-authored-canonical" class="informative">
-				<h3>Authored and Canonical Manifests</h3>
+					<p>This section describes the construction requirements for manifests, and outlines the general set
+						of properties for use with them.</p>
+				</section>
 
-				<p>Depending on the state of a <a>digital publication</a>, its manifest exists in one of two forms:</p>
+				<section id="manifest-jsonld">
+					<h4>JSON-LD Authoring and Processing</h4>
 
-				<dl>
-					<dt>
-						<dfn data-lt="authored publication manifest">Authored Manifest</dfn>
-					</dt>
-					<dd>
-						<p>The Authored Publication Manifest is the serialization of the manifest that the author
-							provides with the digital publication (i.e., prior to be digital publication being processed
-							by a user agent). Note that the author does not have to be human; a machine could
-							automatically produce authored manifests for digital publications.</p>
-					</dd>
+					<p>This specification defines the publication manifest as a specific "shape" of [[!json-ld]]. This
+						means that the manifest SHOULD be expressed using only the syntactical constructions as defined
+						in this specification, as opposed to all the possibilities offered by the JSON-LD syntax.</p>
 
-					<dt>
-						<dfn data-lt="canonical manifest|canonical publication manifest">Canonical Manifest</dfn>
-					</dt>
-					<dd>
-						<p>The Canonical Publication Manifest is a version of the manifest created by user agents when
-							they <a href="#processing-manifest">process the authored manifest</a> and remove all
-							possible ambiguities and incorporate any missing values that can be inferred from another
-							source.</p>
-					</dd>
-				</dl>
+					<p class="note">This shape is also defined, informally, through a JSON schema&#160;[[json-schema]]
+						that expresses the constraints defined in this specification. This schema is maintained at <a
+							href="https://github.com/w3c/pub-manifest/blob/master/schema/publication.schema.json"
+							>https://github.com/w3c/pub-manifest/blob/master/schema/publication.schema.json</a>.</p>
 
-				<p>It is possible that an authored manifest is the equivalent of the canonical manifest if there are no
-					ambiguities or missing information, but a canonical manifest only exists after a user agent has
-					inspected the authored manifest as part of the process of obtaining it.</p>
+					<p>The publication manifest also has a number of authoring flexibilities and compact authoring
+						expressions. For example, it is not always required that object types be explicitly authored, as
+						these are automatically generated during canonicalization when missing (see <a
+							href="#value-objects"></a> for more information). A <a>canonical representation</a> of the
+						manifest data is defined separately; see the separate section on <a href="#webidl"></a> for
+						further details.</p>
 
-				<p>This part of the specification describes the requirements for creating an authored manifest,
-					regardless of the format of the digital publication. Rules for constructing a canonical manifest
-					from the authored manifest are defined for each specific implementation.</p>
-
+					<p>As a consequence, a user agent does not have to be a full JSON-LD processor. User agents only
+						need to be able to read the manifest's specific shape and internalize the data.</p>
+				</section>
 			</section>
 
 			<section id="manifest-requirements">
@@ -204,9 +198,9 @@
 					</li>
 				</ul>
 
-				<p class="note">Not all of these properties have to be serialized in the <a>authored manifest</a>. Refer
-					to each property's definition to determine if and how it is compiled into the <a>canonical
-						manifest</a> from other information.</p>
+				<p class="note">Not all of these properties have to be serialized in the manifest. Refer to each
+					property's definition to determine whether, and how, it is compiled into the <a>canonical
+						representation</a> from other information.</p>
 
 				<p>The priority of all other <a href="#manifest-properties">properties</a> and <a href="#manifest-rel"
 						>resource relations</a> is OPTIONAL, but MAY be modified by implementations of the manifest
@@ -216,15 +210,13 @@
 			<section id="webidl">
 				<h3>Web IDL</h3>
 
-				<p>Although a <a>digital publication</a>'s manifest is authored as [[json-ld]], a user agent processes
-					this information into an internal data structure, which can be in any language, in order to utilize
-					the properties. The exact manner in which this processing occurs, and how the data is used
-					internally, is user agent-dependent and not defined in this specification.</p>
+				<p>Although a <a>digital publication</a>'s manifest is authored as [[!json-ld]], a user agent <a
+						href="#manifest-processing">processes this information</a> into the <a>canonical
+						representation</a>, which can be in any language, in order to utilize the properties.</p>
 
-				<p>To simplify the understanding of the manifest format for developers, this specification defines an
-					abstract representation of the data structures employed by the manifest using the Web Interface
-					Definition Language (Web IDL) [[webidl-1]] — <a href="#webidl-wpm">the
-							<code>PublicationManifest</code> dictionary</a>.</p>
+				<p>To simplify the manifest format for developers, this specification defines an abstract representation
+					of the data structures employed by the manifest using the Web Interface Definition Language (Web
+					IDL) [[!webidl-1]] — <a href="#webidl-wpm">the <code>PublicationManifest</code> dictionary</a>.</p>
 
 				<p>This definition expresses the expected names, datatypes, and possible restrictions for each member of
 					the manifest. Unlike a typical Web IDL definition, however, user agents are not expected to expose
@@ -240,7 +232,7 @@
 					<pre class="idl" id="wpm">
 dictionary PublicationManifest {
     required sequence&lt;DOMString>         type;
-             sequence&lt;DOMString>         id;
+             DOMString                   id;
              sequence&lt;DOMString>         accessMode;
              sequence&lt;DOMString>         accessModeSufficient;
              sequence&lt;DOMString>         accessibilityFeature;
@@ -271,24 +263,11 @@ dictionary PublicationManifest {
              sequence&lt;LinkedResource>    resources = [];
              sequence&lt;LinkedResource>    links = [];
 };
-					
-
-dictionary CreatorInfo {
-             sequence&lt;DOMString>         type;
-    required sequence&lt;LocalizableString> name;
-             DOMString                   id;
-             DOMString                   url;
-};
 
 enum TextDirection {
     "ltr",
     "rtl",
     "auto"
-};
-
-dictionary LocalizableString {
-    required DOMString                   value;
-             DOMString                   language;
 };
 
 enum ProgressionDirection {
@@ -302,9 +281,8 @@ enum ProgressionDirection {
 			<section id="manifest-context">
 				<h3>Manifest Contexts</h3>
 
-				<p>A <a>digital publication's</a>
-					<a>manifest</a> starts by setting the JSON-LD context [[!json-ld]]. The context has the following
-					two major components:</p>
+				<p>A <a>manifest</a> MUST set its JSON-LD context [[!json-ld]]. The context has the following two major
+					components:</p>
 
 				<ul>
 					<li>the [[!schema.org]] context: <code>https://schema.org</code></li>
@@ -424,16 +402,14 @@ enum ProgressionDirection {
 						purpose; the groupings have no relevance outside this specification (i.e., the properties are
 						not actually grouped together in the manifest).</p>
 
-					<div class="note">
-						<p>Each manifest item drawn from schema.org identifies the property it maps to and includes its
-							defining type in parentheses. Properties are often available in many types, however, as a
-							result of the schema.org inheritance model. Refer to each property definition for more
-							detailed information about where it is valid to use.</p>
+					<p>Each manifest item drawn from schema.org identifies the property it maps to and includes its
+						defining type in parentheses. Properties are often available in many types, however, as a result
+						of the schema.org inheritance model. Refer to each property definition for more detailed
+						information about where it is valid to use.</p>
 
-						<p>Schema.org additionally includes a large number of properties that, though relevant for
-							publishing, are not mentioned in this specification — publication authors can use any of
-							these properties. This document defines only the minimal set of manifest items.</p>
-					</div>
+					<p>Schema.org additionally includes a large number of properties that, though relevant for
+						publishing, are not mentioned in this specification. These properties can be used in a manifest
+						as this document defines only the minimal set of manifest items.</p>
 
 					<p class="ednote">There are discussion on whether a best practices document would be created,
 						referring to more schema.org terms. If so, it should be linked from here.</p>
@@ -443,61 +419,67 @@ enum ProgressionDirection {
 					<h4>Value Categories</h4>
 
 					<p>This section describes the categories of values that can be used with properties of the
-						Publication Manifest.</p>
+						publication manifest.</p>
 
 					<section id="value-literal">
 						<h5>Literals</h5>
 
-						<p>Some <a href="#manifest-properties">manifest</a> properties expect a literal text string as
-							their value &#8212; one that is not language-dependent, such as a code value or date. These
-							values are expressed as [[!json]] strings.</p>
+						<p>When a <a href="#manifest-properties">manifest</a> property expects a literal text string as
+							its value &#8212; one that is not language-dependent, such as a code value or date &#8212;
+							its value MUST be expressed as a [[!json]] string.</p>
 
-						<p>Literal values are not changed <a href="#canonical-manifest">during canonicalization of the
+						<p>Literal values are not changed <a href="#manifest-processing">during processing of the
 								manifest</a>, unlike other values which might be, for example, converted to objects.</p>
 					</section>
 
 					<section id="value-number">
 						<h5>Numbers</h5>
 
-						<p> Some <a href="#manifest-properties">manifest</a> properties expect a number as their value.
-							These values are expressed as [[!json]] numbers. </p>
+						<p>When a <a href="#manifest-properties">manifest</a> property expects a number as its value,
+							the values MUST be expressed as a [[!json]] number.</p>
 					</section>
 
 					<section id="value-objects">
 						<h5>Explicit and Implied Objects</h5>
 
 						<p>Various manifest properties are expected to be expressed as [[!json]]&#160;objects. Although
-							the use of objects is usually recommended, it is also acceptable to use string values that
-							are interpreted as objects depending on the context. The exact mapping of text values to
-							objects is part of the property or object definitions.</p>
+							the use of objects is usually recommended, the following sections identify cases where it is
+							also acceptable to use string values that are interpreted as objects depending on the
+							context. The exact mapping of text values to objects is part of the property or object
+							definitions.</p>
 
 						<section id="value-localizable-string">
 							<h5>Localizable Strings</h5>
 
-							<p>Some <a href="#manifest-properties">manifest</a> properties expect a localizable text
-								string as their value. These values are expressed either as:</p>
+							<p>When a <a href="#manifest-properties">manifest</a> property expects a localizable text
+								string as its value, the value MUST be expressed either as:</p>
 
 							<ul>
 								<li>a single string value;</li>
-								<li>an anonymous object with a <code>value</code> property containing a the property's
-									text and a <code>language</code> property that identifies the language of the
-									text.</li>
+								<li>an object with a <code>value</code> property containing a the property's text and a
+										<code>language</code> property that identifies the language of the text.</li>
 							</ul>
 
-							<p>In the case of single string values, these represent a implied object whose
-									<code>value</code> property is the string's text and whose language will be
-								determined from other information in the manifest.</p>
+							<p>A single string value represents an implied object whose <code>value</code> property is
+								the string's text and whose language is determined from other information in the
+								manifest.</p>
 						</section>
 
 						<section id="value-object-entity">
 							<h6>Entities</h6>
 
-							<p>A common case of implied objects in the Publication Manifest properties set is for <a
-									href="#creators">creators</a>. The entities responsible for the various aspects of
-								creation are expressed as [[!schema.org]] <a href="https://schema.org/Person">Person</a>
-								and/or <a href="https://schema.org/Organization">Organization</a> objects. To simplify
-								authoring, however, a simple string value can be used for the entity's name. In this
-								case, the entity is assumed to represent a Person.</p>
+							<p>When a <a href="#manifest-properties">manifest</a> property expects an entity (i.e., an
+								individual or organization responsible for the various aspects of creation), its value
+								MUST be expressed either as:</p>
+
+							<ul>
+								<li>a single string value;</li>
+								<li>a <a href="#CreatorInfo">CreatorInfo</a> object.</li>
+							</ul>
+
+							<p>A single string value represents an instance of a CreatorInfo object whose
+									<code>name</code> property is the string's text and whose <code>type</code> is
+								assumed to be <a href="https://schema.org/Person">Person</a> [[!schema.org]].</p>
 
 							<aside class="example" title="Using a text string instead of a Person object.">
 								<p>The following author name is expressed as a text string:</p>
@@ -524,9 +506,8 @@ enum ProgressionDirection {
 						<section id="value-link">
 							<h5>Links</h5>
 
-							<p>With the exception of the <a href="#descriptive-properties">descriptive properties</a>,
-								manifest properties typically link to one or more resources. When a property requires a
-								link value, the link MUST be expressed in one of the following two ways:</p>
+							<p>When a manifest property links to one or more resources, it MUST be expressed in one of
+								the following two ways:</p>
 
 							<ol>
 								<li>as a string encoding the <a>URL</a> of the resources; or</li>
@@ -535,9 +516,8 @@ enum ProgressionDirection {
 									characteristics of the target resource.</li>
 							</ol>
 
-							<p>In the case of single string values, these represent an implied
-									<code>LinkedResource</code> object whose <code>url</code> property is set to that
-								string value.</p>
+							<p>A single string value represents an implied <code>LinkedResource</code> object whose
+									<code>url</code> property is set to the string value.</p>
 
 							<pre class="example" title="Resource list that includes one link using a relative URL as a string ('datatypes.svg') and two that display the various properties of the a LinkedResource object">
 {
@@ -567,8 +547,9 @@ enum ProgressionDirection {
 						<h5>URLs</h5>
 
 						<p><dfn data-lt="URL">URLs</dfn> are used to identify resources associated with a <a>digital
-								publication</a>. They MUST be <a href="https://url.spec.whatwg.org/#absolute-url-string"
-								>valid URL strings</a> [[!url]].</p>
+								publication</a>. When a property expects a URL value, it MUST be a <a
+								href="https://url.spec.whatwg.org/#absolute-url-string">valid URL string</a>
+							[[!url]].</p>
 
 						<p>Manifest URLs are restricted to only the <code>http</code> and <code>https</code>
 							<a href="https://url.spec.whatwg.org/#concept-url-scheme">schemes</a> [[!url]]. URLs MUST
@@ -620,11 +601,10 @@ enum ProgressionDirection {
 					<section id="value-array">
 						<h5>Arrays</h5>
 
-						<p>Some <a href="#manifest-properties">manifest properties</a> allow one or more value of their
+						<p>When a <a href="#manifest-properties">manifest property</a> allows one or more value of their
 							respective type (<a href="#value-literal">literal</a>, <a href="#value-objects">object</a>,
-							or <a href="#value-url">URL</a>). As a general rule, these values can be expressed as
-							[[!json]]&#160;arrays. When the property value is an array with a single element, however,
-							the array syntax MAY be omitted.</p>
+							or <a href="#value-url">URL</a>), these values are expressed as [[!json]]&#160;arrays. When
+							a property value is a single element, however, the array syntax MAY be omitted.</p>
 
 						<aside class="example" title="Using a text string instead of an array">
 							<p>As a digital publication typically contains many resources, this declaration of a single
@@ -722,7 +702,8 @@ enum ProgressionDirection {
 											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
 								</tr>
 								<tr>
-									<td> b <code data-dfn-for="PublicationManifest">
+									<td>
+										<code data-dfn-for="PublicationManifest">
 											<dfn>accessibilityHazard</dfn>
 										</code>
 									</td>
@@ -878,8 +859,7 @@ enum ProgressionDirection {
 
 						<p>If a canonical identifier is not provided in the manifest, or the value is an invalid URL,
 							the digital publication does not have a canonical identifier. User agents MUST NOT attempt
-							to construct a canonical identifier from any other identifiers provided in the manifest for
-							the canonical manifest.</p>
+							to construct a canonical identifier from any other identifiers provided in the manifest.</p>
 
 						<p>The specification of the canonical identifier MAY be complemented by the inclusion of
 							additional types of identifiers using the <a href="https://schema.org/identifier"
@@ -1151,34 +1131,11 @@ enum ProgressionDirection {
 								<code>Person</code> whose <code>name</code> property is set to that string value. (See
 							also <a href="#value-object-entity"></a>.)</p>
 
-						<p>When compiling each set of <dfn data-lt="CreatorInfo">creator information</dfn> from a
-							[[!schema.org]] <a href="https://schema.org/Person"><code>Person</code></a> or <a
+						<p>When compiling each set of creator information from a [[!schema.org]] <a
+								href="https://schema.org/Person"><code>Person</code></a> or <a
 								href="https://schema.org/Organization"><code>Organization</code></a> type, user agents
-							MUST retain the following information when available:</p>
-
-						<dl data-dfn-for="CreatorInfo">
-							<dt>
-								<dfn>type</dfn>
-							</dt>
-							<dd>One or more strings that identifies the type of creator. This sequence SHOULD include
-								"Person" or "Organization".</dd>
-							<dt>
-								<dfn>name</dfn>
-							</dt>
-							<dd>One or more localizable strings for the name of the creator.</dd>
-							<dt>
-								<dfn>id</dfn>
-							</dt>
-							<dd>A canonical identifier of the creator as an <a>Identifier</a>.</dd>
-
-							<dt>
-								<dfn>url</dfn>
-							</dt>
-							<dd>An address for the creator in the form of a <a>URL</a>.</dd>
-						</dl>
-
-						<p>Note that user agents MAY interpret a wider range of creator properties defined by Schema.org
-							than the ones in the preceding list.</p>
+							MUST retain the properties defined for the <a href="#CreatorInfo">CreatorInfo type</a>, when
+							available.</p>
 
 						<p>The manifest MAY include more than one of each type of creator.</p>
 
@@ -1312,10 +1269,10 @@ enum ProgressionDirection {
 								href="#manifest-specific-language-and-dir">natural language properties values</a> of the
 							manifest.</p>
 
-						<p>If a user agent requires the language and one is not available in the authored manifest
-							(either globally or specifically for that property), or the obtained value is invalid, the
-							user agent MAY attempt to determine the language when <a href="#canonical-manifest"
-								>generating the canonical manifest</a>. This specification does not mandate how such a
+						<p>If a user agent requires the language and one is not available in the manifest (either
+							globally or specifically for that property), or the obtained value is invalid, the user
+							agent MAY attempt to determine the language when <a href="#manifest-processing">generating
+								its canonical representation</a>. This specification does not mandate how such a
 							language tag is created. The user agent might:</p>
 
 						<ul>
@@ -1353,7 +1310,7 @@ enum ProgressionDirection {
 										</td>
 										<td>Default <a>language</a> for the publication as well as the textual manifest
 											values</td>
-										<td>language code as defined in&#160;[[!bcp47]]</td>
+										<td>A language code as defined in&#160;[[!bcp47]]</td>
 										<td>
 											<a href="#value-literal">Literal</a>
 										</td>
@@ -1410,8 +1367,8 @@ enum ProgressionDirection {
 							<h6>Item-specific Language</h6>
 
 							<p>It is possible to set the language for any textual value in the manifest. This
-								information MUST be set as a <dfn data-lt="LocalizableString">localizable string</dfn>,
-								i.e., using the <a
+								information MUST be set as a <a href="#LocalizableString">localizable string</a>, i.e.,
+								using the <a
 									href="https://www.w3.org/TR/2014/REC-json-ld-20140116/#string-internationalization"
 										><code>value</code> and <code>language</code> terms</a> (instead of a simple
 								string)&#160;[[!json-ld]]:</p>
@@ -1430,15 +1387,14 @@ enum ProgressionDirection {
     }
 }
 </pre>
-							<p>The value of the <code data-dfn-for="LocalizableString"><dfn>language</dfn></code> MUST
-								be set to a language code as defined in [[!bcp47]].</p>
+							<p>The value of the <code>language</code> MUST be set to a language code as defined in
+								[[!bcp47]].</p>
 
 							<p>When used in a context of localizable texts, a simple string value is a shorthand for a
-									<a>localizable string</a>, with the <code data-dfn-for="LocalizableString"
-										><dfn>value</dfn></code> set to the string value, and the language set to the
-								value of the <a href="#manifest-default-language-and-dir"><code>inLanguage</code></a>
-								property, if applicable, and unset otherwise. In other words, the previous example is
-								equivalent to:</p>
+									<a>localizable string</a>, with the <code>value</code> set to the string value, and
+								the language set to the value of the <a href="#manifest-default-language-and-dir"
+										><code>inLanguage</code></a> property, if applicable, and unset otherwise. In
+								other words, the previous example is equivalent to:</p>
 
 							<pre class="example" title="Setting the default language of an author name to French">
 {
@@ -1649,7 +1605,7 @@ enum ProgressionDirection {
 							next and previous pages, touch gestures, etc.</p>
 
 						<p>If the <code>readingProgression</code> is not set, user agents MUST use the default value
-								<code>ltr</code> when generating the canonical manifest.</p>
+								<code>ltr</code> when generating their <a>canonical representation</a>.</p>
 
 						<pre class="example" title="Reading progression set explicitl to ltr">
 {
@@ -1698,10 +1654,10 @@ enum ProgressionDirection {
 							</tbody>
 						</table>
 
-						<p id="generate_title">If a title is not included in the <a>authored manifest</a>, and a
-								<a>digital publication</a> does not define alternative rules for obtaining one, the user
-							agent MUST create one. This specification does not specify what heuristics to use to
-							generate such a title.</p>
+						<p id="generate_title">If a title is not included in the manifest, and a <a>digital
+								publication</a> does not define alternative rules for obtaining one, the user agent MUST
+							create one. This specification does not specify what heuristics to use to generate such a
+							title.</p>
 
 						<p class="note">A user agent is not expected to produce a <a
 								data-cite="WCAG20#navigation-mechanisms-title">meaningful title</a>&#160;[[wcag20]] for
@@ -2004,8 +1960,8 @@ enum ProgressionDirection {
 					<p>Although both methods are valid, the use of linked records is RECOMMENDED.</p>
 
 					<p>This specification does not define how such additional properties are compiled, stored or exposed
-						by user agents in their internal representation of the manifest. A user agent MAY ignore some or
-						all extended properties.</p>
+						by user agents in their <a>canonical representation</a> of the manifest. A user agent MAY ignore
+						some or all extended properties.</p>
 
 					<section id="extensibility-linked-records">
 						<h4>Linked records</h4>
@@ -2101,10 +2057,9 @@ enum ProgressionDirection {
 
 					<p>The <a>manifest</a> identifies key resources of a <a>digital publication</a> through the use of
 						link relations. These relations are applied to the <a href="#dom-linkedresource-rel"
-								><code>rel</code> property</a> of <a href="#app-linkedResource"
-								><code>LinkedResource</code> objects</a> (e.g., the links found in the <a
-							href="#pub-table-of-contents">table of contents</a> and <a href="#resource-list">resource
-							list</a>).</p>
+								><code>rel</code> property</a> of <a href="#LinkedResource"><code>LinkedResource</code>
+							objects</a> (e.g., the links found in the <a href="#pub-table-of-contents">table of
+							contents</a> and <a href="#resource-list">resource list</a>).</p>
 
 					<p>The types of resources these relations identify are categorized as follows:</p>
 
@@ -2479,8 +2434,6 @@ enum ProgressionDirection {
 	&lt;/script&gt;
 </pre>
 
-				<p class="issue" data-number="8">The exact value of <code>rel</code> is still to be agreed upon and
-					should be registered by IANA.</p>
 			</section>
 
 			<section id="manifest-embed">
@@ -2493,7 +2446,7 @@ enum ProgressionDirection {
 						href="https://www.w3.org/TR/json-ld11/#embedding-json-ld-in-html-documents"><code>type</code>
 						attribute is set to <code>application/ld+json</code></a> [[!json-ld]].</p>
 
-				<pre class="example" title="A Publication Manifest included in an HTML document">
+				<pre class="example" title="A publication manifest included in an HTML document">
 &lt;script type="application/ld+json"&gt;
    {
       &#8230;
@@ -2509,409 +2462,6 @@ enum ProgressionDirection {
 					no involve linking to, or embedding, a manifest (e.g., that manifest could be discovered through the
 					use of a restricted name and/or location). This specification does not add any restrictions on such
 					methods.</p>
-			</section>
-		</section>
-		<section id="manifest-lifecycle">
-			<h2>Manifest Lifecycle</h2>
-
-			<section id="lifecycle-intro" class="informative">
-				<h3>Introduction</h3>
-
-				<p>This section describes the steps a user agent follows to process an <a>authored manifest</a> into an
-					internal representation of the data structure it contains.</p>
-
-				<p>The first step in this process is to obtain the manifest, the exact steps by which to do so are
-					defined by each <a>digital publication</a> format.</p>
-
-				<p>The process then involves generating a <a data-lt="canonical manifest">canonical form</a> of the
-					manifest, which is a representation that adds any missing data not explicitly authored (e.g.,
-					information could be gleaned from a containing HTML document if the manifest is embedded inside a
-						<code>script</code> tag).</p>
-
-				<p>After a canonical manifest is generated, the data is put through a final set of post-processing steps
-					to check its validity, ultimately resulting in a data structure that the user agent can use.</p>
-
-				<p>Within this process are various extension points that allow <a>digital publication</a> formats to
-					enhance the basic requirements for their own specialized needs and audiences.</p>
-			</section>
-
-			<section id="processing-manifest">
-				<h3>Processing a Manifest</h3>
-
-				<p>The <dfn data-lt="processing the manifest|processing a manifest|process a manifest">steps for
-						processing a manifest</dfn> are given by the following algorithm. The algorithm, if successful,
-					returns a <a>processed manifest</a>; otherwise, it terminates prematurely and returns nothing. In
-					the case of nothing being returned, the user agent MUST ignore the manifest declaration.</p>
-
-				<p>The algorithm takes the following arguments:</p>
-
-				<ul>
-					<li><var>text</var>: a UTF-8 string containing the manifest;</li>
-					<li><var>base</var>: a URL string that represents the base URL for the manifest.</li>
-					<li><var>document</var>: the <a data-cite="!html#the-document-object">HTML Document (DOM) Node</a>
-						of the document that references the manifest, when available.</li>
-				</ul>
-
-				<ol>
-					<li>Let <var>json</var> be the result of <a data-cite="!ecmascript#sec-json.parse">parsing</a>
-						<var>text</var>. If <a data-cite="!ecmascript#sec-json.parse">parsing</a> throws an error,
-						terminate this algorithm. </li>
-
-					<li>If Type(<var>json</var>) is not <code>Object</code>, terminate this algorithm. </li>
-
-					<li>Let <var>canonical manifest</var> be the <a>canonical manifest</a> derived from <var>json</var>,
-						using the values of <var>json</var>, <var>base</var>, and <code>document</code> as input to the
-						algorithm described in <a href="#canonical-manifest"></a>. </li>
-
-					<li id="canon-min-req">
-						<p>Check whether the <var>canonical manifest</var> fulfills the minimal requirements for a
-							Publication Manifest, namely:</p>
-						<ul>
-							<li>the JSON-LD context is set as required in <a href="#manifest-context"></a>;</li>
-							<li>any extension requirements are set as defined in their respective specifications.</li>
-						</ul>
-						<p>If any of these requirements are not met, terminate the algorithm.</p>
-					</li>
-
-					<li>Let <var>processed manifest</var> be the result of <a>post-processing a canonical manifest</a>
-						given <var>canonical manifest</var>. </li>
-
-					<li>Return <var>processed manifest</var>. </li>
-				</ol>
-
-				<p class="note"> The algorithm does not describes how error and warning messages should be reported.
-					This is implementation dependent.</p>
-			</section>
-
-			<section id="canonical-manifest">
-				<h3>Generating a Canonical Manifest</h3>
-
-				<p>The steps to convert a Publication Manifest into a Canonical Manifest are given by the following
-					algorithm. The algorithm takes the following arguments:</p>
-
-				<ul>
-					<li><var>manifest</var>: a JSON object that represent the <a>manifest</a></li>
-					<li><var>base</var>: a URL string that represents the base URL for the manifest</li>
-					<li><var>document</var>: the <a data-cite="!html#the-document-object">HTML Document (DOM) Node</a>
-						of the document that references the manifest, when available.</li>
-				</ul>
-
-				<p>The steps of the algorithm are described below. The algorithm varies from strict JavaScript notation
-					in that <var>P["term"]</var> refers to the value in the object <var>P</var> for the label
-						<var>"term"</var>, where <var>P</var> is either <var>manifest</var> or an object appearing
-					within <var>manifest</var> (e.g., a <var>Person</var>). The algorithm replaces or adds some terms to
-						<var>manifest</var>; the replacement terms are expressed in JSON syntax as <code class="json"
-						>{"term":"value"}</code>.</p>
-
-				<ol>
-					<li>
-						<p>(<a href="#pub-title"></a>) if <var>manifest["name"]</var> is <code>undefined</code>, locate
-							the <a data-cite="!html#the-title-element"><code>title</code></a> element [[!html]] using
-								<var>document</var> (when set). If that element exists and is non-empty, let
-								<var>t</var> be its text content, and add to <var>manifest</var>:</p>
-						<ul>
-							<li>if the language of <code>title</code> is explicitly <a
-									data-cite="!html#the-lang-and-xml:lang-attributes">set</a> to the value of
-									<var>l</var>, then add <br />
-								<code class="json">"name": [{"value": t, "language": l}]</code>
-							</li>
-							<li>otherwise <br />
-								<code class="json">"name": [t]</code><br />
-							</li>
-						</ul>
-						<details>
-							<summary>Explanation</summary>
-							<p>This step adds the content of the <code>title</code> element of <var>document</var> when
-								the <code>name</code> property is not specified in the manifest. For example:</p>
-							<pre class="example">&lt;html&gt;
-&lt;head&gt;
-    &lt;title&gt;Moby Dick&lt;/title&gt;
-    &#8230;
-    &lt;script type="application/ld+json"&gt;
-    {
-        "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-        &#8230;
-    }
-    &lt;/script&gt;</pre>
-							<p>yields:</p>
-							<pre class="example">{
-    "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "name"     : ["Moby Dick"],
-    &#8230;
-}</pre>
-						</details>
-					</li>
-
-					<li id="no-reading-order">
-						<p>(<a href="#default-reading-order"></a>) if <var>manifest["readingOrder"]</var> is
-								<code>undefined</code>, let <var>u</var> be the value of <a
-								data-cite="!dom#concept-document-url">document.URL</a>, and add<br />
-							<code class="json">"readingOrder": [{"type": ["LinkedResource"], "url": u}]</code><br /> to
-							the <var>manifest</var></p>
-						<details>
-							<summary>Explanation</summary>
-							<p> If the Digital Publication consists only of the referencing document, the default
-								reading order can be omitted; it will consist, automatically, of that single resource.
-							</p>
-						</details>
-					</li>
-
-					<li>
-						<p>(<a href="#value-array"></a>) for each value <var>v</var> of <var>P["term"]</var> that is a
-							single string or an object, and where <var>term</var> expects an <a href="#value-array"
-								>array</a>: change the relevant term/value pair to <br />
-							<code class="json">"term": [v]</code></p>
-						<details>
-							<summary>Explanation</summary>
-							<p>A number of terms require their values to be arrays but, for the sake of convenience,
-								authors are allowed to use a single value instead of a one element array. For
-								example,</p>
-							<pre class="example">{
-    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "name"      : "Moby Dick",
-    "author"    : "Herman Melville",
-    "resources" : [{
-        "type"           : "LinkedResource",
-        "rel"            : "cover",
-        "url"            : "images/cover.jpg",
-        "encodingFormat" : "image/jpeg"
-    },
-        &#8230;
-    }],
-    &#8230;
-}</pre>
-							<p>yields:</p>
-							<pre class="example">{
-    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "name"      : ["Moby Dick"],
-    "author"    : ["Herman Melville"],
-    "resources" : [{
-        "type"           : ["LinkedResource"],
-        "rel"            : ["cover"],
-        "url"            : "images/cover.jpg",
-        "encodingFormat" : "image/jpeg"
-    },
-        &#8230;
-    }],
-    &#8230;
-}</pre>
-						</details>
-					</li>
-
-					<li>
-						<p>(<a href="#creators"></a>) for each value <var>v</var> in a <var>manifest["term"]</var> array
-							that is a simple string or a <a>localizable string</a>, and where <var>term</var> expects an
-								<a href="#value-object-entity">entity</a>: exchange that element in the array to <br />
-							<code class="json">{"type": ["Person"], "name": [v]}</code></p>
-						<details>
-							<summary>Explanation</summary>
-							<p>An author, editor, etc., should be explicitly designed as an object of type
-									<code>Person</code> but, for the sake of convenience, authors are allowed to just
-								give their name. For example,</p>
-							<pre class="example">{
-    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "name"      : ["Moby Dick"],
-    "author"    : ["Herman Melville"],
-    &#8230;
-}</pre>
-							<p>yields:</p>
-							<pre class="example">{
-    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "name"      : ["Moby Dick"],
-    "author"    : [{
-        "type" : ["Person"],
-        "name" : "Herman Melville"
-    }],
-    &#8230;
-}</pre>
-						</details>
-					</li>
-
-					<li>
-						<p>(<a href="#value-link"></a>) for each value <var>v</var> in a <var>manifest["term"]</var>
-							array that is a simple string, and where <var>term</var> is one of the <a
-								href="#resource-categorization-properties">resource categorization properties</a>:
-							exchange that element in the array to <br />
-							<code class="json">{"type": ["LinkedResource"], "url": v}</code></p>
-						<details>
-							<summary>Explanation</summary>
-							<p>Resource links should be explicitly designed as an object of type
-									<code>LinkedResource</code> but, for the sake of convenience, authors are allowed to
-								just give their absolute or relative URL. For example,</p>
-							<pre class="example">{
-    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    &#8230;
-    "resources" : [
-        "css/mobydick.css",
-        &#8230;
-    ],
-    &#8230;
-}</pre>
-							<p>yields:</p>
-							<pre class="example">{
-    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    &#8230;
-    "resources" : [{
-        "type" : ["LinkedResource"],
-        "url"  : "css/mobydick.css"
-    },
-        &#8230;
-    ],
-    &#8230;
-}</pre>
-						</details>
-					</li>
-
-					<li>
-						<p>(<a href="#value-localizable-string"></a>) for each value <var>v</var> of
-								<var>P["term"]</var>, or in <var>P["term"]</var> in the case the latter is an array,
-							that is a simple string, and <var>term</var> expects a <a href="#value-localizable-string"
-								>localizable string</a>: change the relevant term/value to:</p>
-						<ul>
-							<li>if <var>manifest[inLanguage]</var> is set to the value of <var>l</var> then<br />
-								<code class="json">"term": {"value": v,"language": l}</code>
-							</li>
-							<li>otherwise<br />
-								<code class="json">"term": {"value": v}</code></li>
-						</ul>
-						<details>
-							<summary>Explanation</summary>
-							<p>Natural language text values should be explicitly designed as localizable string objects
-								but, for the sake of convenience, authors are allowed to just use a simple string. I.e.,
-								if no language information has been provided (via <code>inLanguage</code>) in the
-								manifest then, for example,</p>
-							<pre class="example">{
-    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "name"      : ["Moby Dick"],
-    "author"    : ["Herman Melville"],
-    &#8230;
-}</pre>
-							<p>yields:</p>
-							<pre class="example">{
-    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "name"      : [{
-        "value" : "Moby Dick"
-    }],
-    "author"    : [{
-        "value" : "Herman Melville"
-    }],
-    &#8230;
-}</pre>
-							<p>If an explicit language has also been provided in the manifest, that language is also
-								added to the localizable string object. For example,</p>
-							<pre class="example">{
-    "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "inLanguage" : "en",
-    "name"       : ["Moby Dick"],
-    "author"     : ["Herman Melville"],
-    &#8230;
-}</pre>
-							<p>yields:</p>
-							<pre class="example">{
-    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "inLanguage": "en",
-    "name"      : [{
-        "value"    : "Moby Dick",
-        "language" : "en"
-    }],
-    "author"    : [{
-        "value"    : "Herman Melville"
-        "language" : "en"
-    }],
-    &#8230;
-}</pre>
-						</details>
-					</li>
-
-					<li>
-						<p>(<a href="#value-url"></a>) for each value <var>v</var> of <var>P["term"]</var> that is not
-							an <a data-cite="!url/#absolute-url-string">absolute URL string</a>, and where
-								<var>term</var> expects a <a href="#value-url">URL</a>: resolve this value, considered
-							to be a relative URL, using the value of <var>base</var> and yielding the value of
-								<var>au</var>, and replace the term/value pair by<br />
-							<code class="json">"term": au</code></p>
-						<details>
-							<summary>Explanation</summary>
-							<p>All relative URLs in the Publication Manifest must be resolved against the base value to
-								yield absolute URLs.</p>
-						</details>
-					</li>
-
-					<li id="canonicalization-extension-point">
-						<p>(<a href="#mod-compat"></a>, extension point) if a <a>profile</a> defines its own
-							canonicalization steps for profile specific terms, those steps are executed at this
-							point.</p>
-					</li>
-
-					<li>
-						<p>Return the (transformed) <code>manifest</code>.</p>
-					</li>
-				</ol>
-
-				<p class="note">See the <a href="#canonicalize-manifest-diagram">diagram in the appendix</a> for a
-					visual representation of the algorithm. Also, to help understanding the result of the algorithm,
-					there is a link to the corresponding canonical manifests for all the examples in <a
-						href="#app-manifest-examples"></a>.</p>
-
-				<p class="issue" data-number="9"></p>
-			</section>
-
-			<section id="post-processed-manifest">
-				<h3>Post-Processing a Canonical Manifest</h3>
-
-				<p>The <dfn data-lt="post-process the canonical manifest|post-processing a canonical manifest">steps for
-						post-processing a canonical manifest</dfn> are given by the following algorithm. The algorithm
-					takes a <var>json</var> object representing a <a>canonical manifest</a>. The output from inputting a
-					JSON object into this algorithm is a <dfn>processed manifest</dfn>. The goal of the algorithm is to
-					ensure that the data represented in <var>json</var> abides to the minimal requirements on the data,
-					removing, if applicable, non-conformant data.</p>
-
-				<p>As an abuse of notation, <var>P["term"]</var> refers to the value in the object <var>P</var> for the
-					label <var>"term"</var>, where <var>P</var> is either <var>manifest</var>, or an object appearing
-					within <var>manifest</var> (e.g., a <var>LinkedResource</var>).</p>
-
-				<ol>
-					<li>
-						<p>Let <var>manifest</var> be the result of <a data-cite="!webidl-1/#es-dictionary"
-								>converting</a>
-							<var>json</var> to a <a>PublicationManifest</a> dictionary.</p>
-					</li>
-					<li><p>Perform data cleanup operations on <var>manifest</var>, possibly removing data, as well as
-							raising warnings.</p>
-						<ol>
-							<li>Check whether the value of <var>manifest["type"]</var> is empty. If it is, set the value
-								to "<code>CreativeWork</code>" and issue a warning.</li>
-							<li>For all <var>term</var> that expect <a href="#value-object-entity">entities</a>, check
-								whether the value object <var>P</var> in <var>manifest[term]</var> has
-									<var>P["name"]</var> set. If not, remove <var>P</var> from <var>manifest[term]</var>
-								array and issue a warning. </li>
-							<li>For all <var>term</var> defined in <a href="#resource-categorization-properties"></a>,
-								check whether every object <var>P</var> in <var>manifest[term]</var> has
-									<var>P["url"]</var> set. If not, remove <var>P</var> from <var>manifest[term]</var>
-								array and issue a warning. If yes, check whether <var>P["url"]</var> is a valid
-								URL&#160;[[!url]] and, if not, issue a warning. </li>
-							<li>For every object <var>P</var> of type <a>LinkedResource</a>, if the value of
-									<var>P["length"]</var> is set, check whether this value is a valid number. If the
-								check fails, issue a warning.</li>
-							<li>Check whether the value of <var>manifest["name"]</var> is empty. If it is, generate a
-								value (see the <a href="#generate_title">separate note for details</a>) and issue a
-								warning. </li>
-							<li>Check whether <var>manifest["datePublished"]</var> is a valid date or date-time,
-								per&#160;[[!iso8601]]. If the check fails, issue a warning. </li>
-							<li>Check whether <var>manifest["dateModified"]</var> is a valid date or date-time,
-								per&#160;[[!iso8601]]. If the check fails, issue a warning. </li>
-							<li>Check whether <var>manifest["duration"]</var> is a valid duration value,
-								per&#160;[[!iso8601]]. If the check fails, issue a warning.</li>
-						</ol>
-					</li>
-					<li>
-						<p>Extension point: process any proprietary, <a>profile</a> specific, and/or other supported
-							members at this point in the algorithm.</p>
-					</li>
-					<li>
-						<p>Return <var>manifest</var>.</p>
-					</li>
-				</ol>
 			</section>
 		</section>
 		<section id="extensions">
@@ -2934,9 +2484,9 @@ enum ProgressionDirection {
 
 				<ul>
 					<li>It MUST adhere to the manifest format requirements defined in this specification.</li>
-					<li>The generic canonicalization steps described in <a href="#canonical-manifest"></a> MUST remain
-						valid for the extended manifest. To achieve this, and if new terms are added to the general
-						manifest, then: <ul>
+					<li>The generic processing steps described in <a href="#manifest-processing"></a> MUST remain valid
+						for the extended manifest. To achieve this, and if new terms are added to the general manifest,
+						then: <ul>
 							<li>The term SHOULD be categorized, if applicable, to one or more of the general term
 								categories used in the algorithm (e.g., <a href="#value-array">array</a> or <a
 									href="#value-localizable-string">localizable string</a>). This means the relevant
@@ -2944,173 +2494,578 @@ enum ProgressionDirection {
 							<li>If necessary, the profile MAY define its own canonicalization step, to be executed as
 								the <a href="#canonicalization-extension-point">last step of the general
 									canonicalization algorithm</a>. Such an extra step MUST NOT invalidate the results
-								of any of the steps defined for the <a href="#canonical-manifest">canonicalization
+								of any of the steps defined for the <a href="#manifest-processing">processing
 									algorithm</a> in general. </li>
 						</ul>
 					</li>
 					<li>If necessary, the profile MAY define its own manifest processing step, to be executed as part of
-						the steps described in <a href="#processing-manifest"></a>
+						the steps described in <a href="#manifest-processing"></a>
 					</li>
 				</ul>
 				<p class="ednote"> Adding an example of a term added by, e.g., the audiobook profile would be a good
 					idea, when available. </p>
 			</section>
 		</section>
-		<section id="app-linkedResource" class="appendix">
-			<h5><code>LinkedResource</code> Definition</h5>
+		<section id="manifest-processing">
+			<h2>Processing a Manifest</h2>
 
-			<p id="publication-link-def">This specification defines a new type for links called
-						<code><dfn>LinkedResource</dfn></code>. It consists of the following properties:</p>
+			<p>The <dfn data-lt="processing the manifest|processing a manifest|process a manifest">steps for processing
+					a manifest</dfn> into its <a>canonical representation</a> are given by the following algorithm. If
+				the algorithm terminates early, the manifest is not valid.</p>
 
-			<table class="zebra" data-dfn-for="LinkedResource">
-				<thead>
-					<tr>
-						<th>Term</th>
-						<th>Description</th>
-						<th>Required Value</th>
-						<th>Value Type</th>
-						<th>[[!schema.org]] Mapping</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>
-							<code>
-								<dfn>url</dfn>
-							</code>
-						</td>
-						<td>Location of the resource. REQUIRED.</td>
-						<td>A valid URL string&#160;[[!url]]. Refer to the property definitions that accept this type
-							for additional restrictions.</td>
-						<td>
-							<a href="#value-url">URL</a>
-						</td>
-						<td>
-							<a href="https://schema.org/url">
-								<code>url</code>
-							</a>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<code>
-								<dfn>encodingFormat</dfn>
-							</code>
-						</td>
-						<td>Media type of the resource (e.g., <code>text/html</code>). OPTIONAL.</td>
-						<td>MIME Media Type&#160;[[!rfc2046]].</td>
-						<td>
-							<a href="#value-literal">Literal</a>
-						</td>
-						<td>
-							<a href="https://schema.org/encodingFormat">
-								<code>encodingFormat</code>
-							</a>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<code>
-								<dfn>name</dfn>
-							</code>
-						</td>
-						<td>Name of the item. OPTIONAL.</td>
-						<td>One or more Text items.</td>
-						<td>
-							<a href="#value-array">Array</a> of <a href="#value-localizable-string">Localizable
-								Strings</a>
-						</td>
-						<td>
-							<a href="https://schema.org/name">
-								<code>name</code>
-							</a>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<code>
-								<dfn>description</dfn>
-							</code>
-						</td>
-						<td>Description of the item. OPTIONAL.</td>
-						<td>Text.</td>
-						<td>
-							<a href="#value-localizable-string">Localizable String</a>
-						</td>
-						<td>
-							<a href="https://schema.org/description">
-								<code>description</code>
-							</a>
-						</td>
-					</tr>
-					<tr>
-						<td>
-							<code>
-								<dfn>rel</dfn>
-							</code>
-						</td>
-						<td>The relation of the resource to the publication. OPTIONAL.</td>
-						<td>
-							<p>One or more <a href="#manifest-rel">relations</a>. The values are either the relevant
-								relation terms of the IANA link registry&#160;[[!iana-link-relations]], or
-								specially-defined URLs if no suitable link registry item exists.</p>
-						</td>
-						<td>
-							<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
-						</td>
-						<td>(None)</td>
-					</tr>
-					<tr>
-						<td>
-							<code><dfn>integrity</dfn></code>
-						</td>
-						<td>A cryptographic hashing of the resource that allows its integrity to be verified.
-							OPTIONAL.</td>
-						<td><p>One or more whitespace-separated sets of <a
-									href="https://www.w3.org/TR/SRI/#dfn-integrity-metadata">integrity metadata</a>
-								[[!sri]]. The value MUST conform to the <a
-									href="https://www.w3.org/TR/SRI/#the-integrity-attribute">metadata definition</a>
-								[[!sri]].</p>
-							<p>Refer to [[!sri]] for the <a
-									href="https://www.w3.org/TR/SRI/#cryptographic-hash-functions">list of cryptographic
-									hashing functions</a> that user agents are expected to support.</p>
-						</td>
-						<td>
-							<a href="#value-literal">Literal</a>
-						</td>
-						<td>(None)</td>
-					</tr>
-					<tr>
-						<td>
-							<code>
-								<dfn>length</dfn>
-							</code>
-						</td>
-						<td>The total length of a time-based media resource in (possibly fractional) seconds.
-							OPTIONAL</td>
-						<td> Number </td>
-						<td>
-							<a href="#value-number">Number</a>
-						</td>
-						<td>(None)</td>
-					</tr>
-				</tbody>
-			</table>
+			<p>The algorithm takes the following arguments:</p>
 
-			<p>Although user agent support for the <code>integrity</code> property is OPTIONAL, user agents that support
-				cryptographic hashing comparisons using this property MUST do so in accordance with [[!sri]].</p>
+			<ul>
+				<li><var>text</var>: a UTF-8 string containing the manifest;</li>
+				<li><var>base</var>: a URL string that represents the base URL for the manifest.</li>
+				<li><var>document</var>: the <a data-cite="html#the-document-object">HTML Document (DOM) Node</a>
+					[[html]] of the document that <a href="#manifest-discovery">references the manifest</a>, when
+					available.</li>
+			</ul>
 
-			<aside class="example" title="A resource with a SHA-256 hashing of its content">
-				<pre>{
+			<p class="note">This algorithm does not define how the manifest is discovered and obtained. The steps by
+				which to do so are defined by each <a>digital publication</a> format.</p>
+
+			<p class="note">For illustrative purposes, the examples in this section show the structure of internal
+				representation as JavaScript objects. User agents can process and internalize the resulting structure in
+				whatever language and form is appropriate.</p>
+
+			<ol>
+				<li>
+					<p>Let <var>processed</var> be an object containing the <a>canonical representation</a> of the
+						manifest.</p>
+				</li>
+
+				<li>
+					<p>Let <var>manifest</var> be the result of <a data-cite="ecmascript#sec-json.parse">parsing</a>
+						<var>text</var> as JSON [[!ecmascript]]. If parsing throws an error, terminate this
+						algorithm.</p>
+				</li>
+
+				<li>
+					<p>If typeof(<var>manifest</var>) is not <code>Object</code> [[!ecmascript]], terminate this
+						algorithm.</p>
+				</li>
+
+				<li>
+					<p>(<a href="#manifest-context"></a>) If <var>manifest["@context"]</var> does not contain the values
+							"<code>https://schema.org</code>" and "<code>https://www.w3.org/ns/pub-context</code>" (in
+						this order), issue an error and terminate this algorithm.</p>
+				</li>
+
+				<li>
+					<p>Iterate over each property <var>term</var> in <var>manifest</var> and expand its value, as
+						necessary, as follows. More than one step MAY apply.</p>
+					<p class="note"> The steps below depend on the expected value category of a <var>term</var>. Care
+						should be taken that the value category may depend not only on the name of the term, but also on
+						the object it is used for. For example, the value category for the term <code>url</code> is an
+						Array (of URLs) when used for the <code>PublicationManifest</code> object, but a single URL
+						literal otherwise. </p>
+					<p>For this step, the variable <var>current</var> is set to the value of <var>manifest[term]</var>
+						and is updated by each applicable transformation.</p>
+					<ol style="list-style-type: lower-alpha;">
+						<li>
+							<p>(<a href="#value-array"></a>) If <var>term</var> expects an <a href="#value-array"
+									>array</a> but <var>current</var> contains a string or object <var>value</var>,
+								convert <var>current</var> to an array and push <var>value</var> onto it.</p>
+							<details>
+								<summary>Explanation</summary>
+								<p>A number of terms require their values to be arrays but, for the sake of convenience,
+									authors are allowed to use a single value instead of a one element array. For
+									example,</p>
+								<pre class="example">{
+    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    "name"      : "Moby Dick",
+    "author"    : "Herman Melville",
+    "resources" : [{
+        "type"           : "LinkedResource",
+        "rel"            : "cover",
+        "url"            : "images/cover.jpg",
+        "encodingFormat" : "image/jpeg"
+    },
+        &#8230;
+    }],
+    &#8230;
+}</pre>
+								<p>yields:</p>
+								<pre class="example">{
+    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    "name"      : ["Moby Dick"],
+    "author"    : ["Herman Melville"],
+    "resources" : [{
+        "type"           : ["LinkedResource"],
+        "rel"            : ["cover"],
+        "url"            : "images/cover.jpg",
+        "encodingFormat" : "image/jpeg"
+    },
+        &#8230;
+    }],
+    &#8230;
+}</pre>
+							</details>
+						</li>
+
+						<li>
+							<p>(<a href="#value-object-entity"></a>) If <var>term</var> expects an <a
+									href="#value-object-entity">entity</a> but the value of <var>current</var> is a
+								string <var>str</var>, convert <var>current</var> to an object with the following
+								properties:</p>
+							<ul>
+								<li><p><var>type</var> &#8211; set to an array with the value
+									"<code>Person</code>";</p></li>
+								<li><p><var>name</var> &#8211; set to <var>str</var>.</p></li>
+							</ul>
+							<p>If typeof(<var>current</var>) is <code>Array</code> [[!ecmascript]], perform this step on
+								each value of the array.</p>
+							<details>
+								<summary>Explanation</summary>
+								<p>Authors, editors, etc., are expected to be explicitly designed as an object of type
+										<code>Person</code> but, for the sake of convenience, only their name has to be
+									specified. For example:</p>
+								<pre class="example">{
+    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    "author"    : ["Herman Melville"],
+    &#8230;
+}</pre>
+								<p>This rule converts the string values to objects, yielding the following for the
+									preceding example:</p>
+								<pre class="example">{
+    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    "author"    : [{
+        "type" : ["Person"],
+        "name" : "Herman Melville"
+    }],
+    &#8230;
+}</pre>
+								<p class="note">For simplicity, the conversion of <var>name</var> to a localizable
+									string is described by a later step.</p>
+							</details>
+						</li>
+
+						<li id="step-localizable-string">
+							<p>(<a href="#value-localizable-string"></a>) If <var>term</var> expects a <a
+									href="#value-localizable-string">localizable string</a> and <var>current</var>
+								contains a string <var>str</var>, convert <var>current</var> to an object with the
+								following properties:</p>
+							<ul>
+								<li>
+									<p><var>value</var> &#8211; set to <var>str</var>; and</p>
+								</li>
+								<li>
+									<p><var>language</var> &#8211; set to the value of <var>manifest["inLanguage"]</var>
+										when that property is specified, otherwise omitted.</p>
+								</li>
+							</ul>
+							<p>If typeof(<var>current</var>) is <code>Array</code> [[!ecmascript]], perform this step on
+								each value of the array.</p>
+							<p>If typeof(<var>current</var>) is <code>Object</code> [[!ecmascript]], perform this step
+								on each property of the object.</p>
+							<details>
+								<summary>Explanation</summary>
+								<p>Natural language text values are expected to be explicitly designed as localizable
+									string objects but, for the sake of convenience, can be simple strings For example,
+									if no language information has been provided via <code>inLanguage</code> in the
+									manifest then:</p>
+								<pre class="example">{
+    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    "name"      : ["Moby Dick"],
+    &#8230;
+}</pre>
+								<p>yields:</p>
+								<pre class="example">{
+    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    "name"      : [{
+        "value" : "Moby Dick"
+    }],
+    &#8230;
+}</pre>
+								<p>If an explicit language has also been provided in the manifest, that language is also
+									added to the localizable string object. For example,</p>
+								<pre class="example">{
+    "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    "inLanguage" : "en",
+    "name"       : ["Moby Dick"],
+    &#8230;
+}</pre>
+								<p>yields:</p>
+								<pre class="example">{
+    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    "inLanguage": "en",
+    "name"      : [{
+        "value"    : "Moby Dick",
+        "language" : "en"
+    }],
+    &#8230;
+}</pre>
+							</details>
+						</li>
+
+						<li>
+							<p>(<a href="#value-link"></a>) If <var>term</var> is a <a
+									href="#resource-categorization-properties">resource categorization property</a> and
+								any value in the array in <var>current</var> is a string, convert each string
+									<var>str</var> to an object with the following properties:</p>
+							<ul>
+								<li><var>type</var> &#8211; set to an array with the value
+									"<code>LinkedResource</code>"; and</li>
+								<li><var>url</var> &#8211; set to <var>str</var>.</li>
+							</ul>
+							<details>
+								<summary>Explanation</summary>
+								<p>Resource links are expected to be explicitly designed as an object of type
+										<code>LinkedResource</code> but, for the sake of convenience, only their
+									absolute or relative URL has to be specified. For example,</p>
+								<pre class="example">{
+    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    &#8230;
+    "resources" : [
+        "css/mobydick.css",
+        &#8230;
+    ],
+    &#8230;
+}</pre>
+								<p>This step converts the string values to objects, yielding the following for the
+									preceding example:</p>
+								<pre class="example">{
+    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    &#8230;
+    "resources" : [{
+        "type" : ["LinkedResource"],
+        "url"  : "css/mobydick.css"
+    },
+        &#8230;
+    ],
+    &#8230;
+}</pre>
+								<p class="note">For simplicity, the conversion of relative paths to absolute is
+									described by a later step.</p>
+							</details>
+						</li>
+
+						<li>
+							<p>(<a href="#value-url"></a>) If <var>term</var> expects a <a href="#value-url">URL</a> and
+								the value of <var>current</var> is a string that is not an <a
+									data-cite="!url/#absolute-url-string">absolute URL string</a>, resolve the value
+								using the value of <var>base</var> [[!rfc1808]].</p>
+							<p>If typeof(<var>current</var>) is <code>Array</code> [[!ecmascript]], perform this step on
+								each value of the array.</p>
+							<p>If typeof(<var>current</var>) is <code>Object</code> [[!ecmascript]], perform this step
+								on each property of the object.</p>
+							<details>
+								<summary>Explanation</summary>
+								<p>All relative URLs in the publication manifest must be resolved against the base value
+									to yield absolute URLs.</p>
+							</details>
+						</li>
+
+						<li id="canonicalization-extension-point">
+							<p>(<a href="#mod-compat"></a>, extension point) if a <a>profile</a> defines processing
+								steps for profile-specific terms, those steps are executed at this point.</p>
+						</li>
+					</ol>
+					<p>Set <var>processed[term]</var> to the value of <var>current</var>.</p>
+				</li>
+
+				<li>
+					<p>Add defaults from <var>document</var> for the following properties, when applicable:</p>
+					<ol style="list-style-type: lower-alpha;">
+						<li>
+							<p>(<a href="#pub-title"></a>) If <var>processed["name"]</var> is not set, or its value is
+								an empty string:</p>
+							<ul>
+								<li>Create a new <var>object</var>: <ul>
+										<li> if the <a data-cite="html#the-title-element"><code>title</code></a> element
+											[[html]] of <var>document</var> is set and its contains is not empty, set
+												<var>object["value"]</var> to the text content of the <code>title</code>
+											element and, if applicable, set <var>object["language"]</var> to the <a
+												data-cite="html#the-lang-and-xml:lang-attributes"
+											>language</a>&#160;[[html]]. </li>
+										<li> otherwise, generate a value for <var>object["value"]</var> (see the <a
+												href="#generate_title">separate note for details</a>) and issue a
+											warning. </li>
+									</ul>
+								</li>
+								<li>Set <var>processed["name"]</var> to an empty array and push <var>object</var> onto
+									it.</li>
+							</ul>
+							<details>
+								<summary>Explanation</summary>
+								<p>This step adds the content of the <code>title</code> element of <var>document</var>
+									when the <code>name</code> property is not specified in the manifest. For
+									example:</p>
+								<pre class="example">&lt;html&gt;
+&lt;head lang="en"&gt;
+    &lt;title&gt;Moby Dick&lt;/title&gt;
+    &#8230;
+    &lt;script type="application/ld+json"&gt;
+    {
+        "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+        &#8230;
+    }
+    &lt;/script&gt;</pre>
+								<p>yields:</p>
+								<pre class="example">{
+    "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    "name"     : [{
+        "value" : "Moby Dick",
+        "language" : "en"
+    }],
+    &#8230;
+}</pre>
+							</details>
+						</li>
+
+						<li id="reading-order">
+							<p>(<a href="#default-reading-order"></a>) If <var>processed["readingOrder"]</var> is not
+								set or its value is an empty string or array, create an object:</p>
+							<ul>
+								<li>if <a data-cite="!dom#concept-document-url">document.URL</a> is not set, issue an
+									error and terminate this algorithm.</li>
+								<li>otherwise, create an object and set its <var>url</var> property to the value of <a
+										data-cite="!dom#concept-document-url">document.URL</a>. Set
+										<var>processed["readingOrder"]</var> to an empty array and push the object onto
+									it. </li>
+							</ul>
+							<details>
+								<summary>Explanation</summary>
+								<p> If the Digital Publication consists only of the referencing document, the default
+									reading order can be omitted; it will consist, automatically, of that single
+									resource. </p>
+							</details>
+						</li>
+
+						<li id="html-extension-point">
+							<p>If a <a>profile</a> specifies <var>document</var> fallbacks, those steps are executed at
+								this point.</p>
+						</li>
+					</ol>
+				</li>
+
+				<li>
+					<p>Perform data integrity checks on the following properties in <var>processed</var>:</p>
+					<ol style="list-style-type: lower-alpha;">
+						<li>
+							<p>For each property <var>term</var> in <var>processed</var> that expects an array of <a
+									href="#value-object-entity">entities</a>, check whether each value <var>entry</var>
+								in <var>processed[term]</var> has its <var>name</var> property set. If not, remove
+									<var>entry</var> from <var>processed[term]</var> and issue a warning.</p>
+							<p>Repeat this step recursively for all properties of <var>current</var> that expect an
+								object in which one or more properties expect entities.</p>
+						</li>
+
+						<li>
+							<p>(<a href="#publication-types"></a>) If <var>processed["type"]</var> is not set or
+								contains an empty value, set its value to an array with the value
+									"<code>CreativeWork</code>" and issue a warning.</p>
+						</li>
+
+						<li>
+							<p>(<a href="#duration"></a>) If <var>processed["duration"]</var> is set and its value is
+								not a valid duration value, per&#160;[[!iso8601]], issue a warning.</p>
+						</li>
+
+						<li>
+							<p>(<a href="#last-modification-date"></a>) If <var>processed["dateModified"]</var> is set
+								and its value is not a valid date or date-time per&#160;[[!iso8601]], issue a
+								warning.</p>
+						</li>
+
+						<li>
+							<p>(<a href="#publication-date"></a>) If <var>processed["datePublished"]</var> is set and
+								its value is not a valid date or date-time per&#160;[[!iso8601]], issue a warning.</p>
+						</li>
+
+						<li>
+							<p>(<a href="#resource-categorization-properties"></a>) For each <a
+									href="#resource-categorization-properties">resource categorization property</a>
+								<var>term</var>, check whether each object <var>P</var> in <var>processed[term]</var>
+								has <var>P["url"]</var> set:</p>
+							<ul>
+								<li>
+									<p>If not, remove <var>P</var> from <var>processed[term]</var> array and issue a
+										warning.</p>
+								</li>
+								<li>
+									<p>Otherwise, check whether <var>P["url"]</var> is a valid URL&#160;[[!url]] and, if
+										not, issue a warning.</p>
+								</li>
+							</ul>
+						</li>
+
+						<li>
+							<p>(<a href="#LinkedResource"></a>) If <var>term</var> is type <a>LinkedResource</a> and the
+								value of <var>current["length"]</var> is set, check whether this value is a valid number
+								and issue a warning if not.</p>
+						</li>
+
+						<li>If a <a>profile</a> specifies data validation checks, those steps are executed at this
+							point.</li>
+					</ol>
+				</li>
+			</ol>
+
+			<p class="note"> How error and warning messages are reported is user agent dependent.</p>
+		</section>
+		<section id="app-custom-types" class="appendix">
+			<h2>Custom Type Definition</h2>
+
+			<section id="LinkedResource">
+				<h3><code>LinkedResource</code> Definition</h3>
+
+				<p id="publication-link-def">This specification defines a new type for links called
+							<code><dfn>LinkedResource</dfn></code>. It consists of the following properties:</p>
+
+				<table class="zebra" data-dfn-for="LinkedResource">
+					<thead>
+						<tr>
+							<th>Term</th>
+							<th>Description</th>
+							<th>Required Value</th>
+							<th>Value Type</th>
+							<th>[[!schema.org]] Mapping</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>
+								<code>
+									<dfn>url</dfn>
+								</code>
+							</td>
+							<td>Location of the resource. REQUIRED.</td>
+							<td>A valid URL string&#160;[[!url]]. Refer to the property definitions that accept this
+								type for additional restrictions.</td>
+							<td>
+								<a href="#value-url">URL</a>
+							</td>
+							<td>
+								<a href="https://schema.org/url">
+									<code>url</code>
+								</a>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<code>
+									<dfn>encodingFormat</dfn>
+								</code>
+							</td>
+							<td>Media type of the resource (e.g., <code>text/html</code>). OPTIONAL.</td>
+							<td>MIME Media Type&#160;[[!rfc2046]].</td>
+							<td>
+								<a href="#value-literal">Literal</a>
+							</td>
+							<td>
+								<a href="https://schema.org/encodingFormat">
+									<code>encodingFormat</code>
+								</a>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<code>
+									<dfn>name</dfn>
+								</code>
+							</td>
+							<td>Name of the item. OPTIONAL.</td>
+							<td>One or more Text items.</td>
+							<td>
+								<a href="#value-array">Array</a> of <a href="#value-localizable-string">Localizable
+									Strings</a>
+							</td>
+							<td>
+								<a href="https://schema.org/name">
+									<code>name</code>
+								</a>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<code>
+									<dfn>description</dfn>
+								</code>
+							</td>
+							<td>Description of the item. OPTIONAL.</td>
+							<td>Text.</td>
+							<td>
+								<a href="#value-localizable-string">Localizable String</a>
+							</td>
+							<td>
+								<a href="https://schema.org/description">
+									<code>description</code>
+								</a>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<code>
+									<dfn>rel</dfn>
+								</code>
+							</td>
+							<td>The relation of the resource to the publication. OPTIONAL.</td>
+							<td>
+								<p>One or more <a href="#manifest-rel">relations</a>. The values are either the relevant
+									relation terms of the IANA link registry&#160;[[!iana-link-relations]], or
+									specially-defined URLs if no suitable link registry item exists.</p>
+							</td>
+							<td>
+								<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
+							</td>
+							<td>(None)</td>
+						</tr>
+						<tr>
+							<td>
+								<code><dfn>integrity</dfn></code>
+							</td>
+							<td>A cryptographic hashing of the resource that allows its integrity to be verified.
+								OPTIONAL.</td>
+							<td><p>One or more whitespace-separated sets of <a
+										href="https://www.w3.org/TR/SRI/#dfn-integrity-metadata">integrity metadata</a>
+									[[!sri]]. The value MUST conform to the <a
+										href="https://www.w3.org/TR/SRI/#the-integrity-attribute">metadata
+										definition</a> [[!sri]].</p>
+								<p>Refer to [[!sri]] for the <a
+										href="https://www.w3.org/TR/SRI/#cryptographic-hash-functions">list of
+										cryptographic hashing functions</a> that user agents are expected to
+									support.</p>
+							</td>
+							<td>
+								<a href="#value-literal">Literal</a>
+							</td>
+							<td>(None)</td>
+						</tr>
+						<tr>
+							<td>
+								<code>
+									<dfn>length</dfn>
+								</code>
+							</td>
+							<td>The total length of a time-based media resource in (possibly fractional) seconds.
+								OPTIONAL</td>
+							<td> Number </td>
+							<td>
+								<a href="#value-number">Number</a>
+							</td>
+							<td>(None)</td>
+						</tr>
+					</tbody>
+				</table>
+
+				<p>Although user agent support for the <code>integrity</code> property is OPTIONAL, user agents that
+					support cryptographic hashing comparisons using this property MUST do so in accordance with
+					[[!sri]].</p>
+
+				<aside class="example" title="A resource with a SHA-256 hashing of its content">
+					<pre>{
     "type":           "LinkedResource",
     "url":            "chapter1.html",
     "encodingFormat": "text/html",
     "name":           "Chapter 1 - Loomings",
     "integrity":      "sha256-13AE04E21177BABEDFDE721577615A638341F963731EA936BBB8C3862F57CDFC"
 }</pre>
-			</aside>
+				</aside>
 
-			<pre class="idl">
+				<pre class="idl">
 dictionary LinkedResource {
     required DOMString           url;
              DOMString           encodingFormat;
@@ -3120,6 +3075,154 @@ dictionary LinkedResource {
              DOMString           integrity;
              double              length;
 };</pre>
+			</section>
+
+			<section id="CreatorInfo">
+				<h3><code>CreatorInfo</code> Definition</h3>
+
+				<p id="creatorinfo-link-def">This specification defines a new type for <a href="#creators">creators</a>
+					called <code><dfn>CreatorInfo</dfn></code>. It consists of the following properties:</p>
+
+				<table class="zebra" data-dfn-for="CreatorInfo">
+					<thead>
+						<tr>
+							<th>Term</th>
+							<th>Description</th>
+							<th>Required Value</th>
+							<th>Value Type</th>
+							<th>[[!schema.org]] Mapping</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>
+								<code>
+									<dfn>type</dfn>
+								</code>
+							</td>
+							<td>The type of creator. OPTIONAL</td>
+							<td>One or more Text. Sequence should include "<code>Person</code>" or
+									"<code>Organization</code>".</td>
+							<td>
+								<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
+							</td>
+							<td>(None)</td>
+						</tr>
+						<tr>
+							<td>
+								<code>
+									<dfn>name</dfn>
+								</code>
+							</td>
+							<td>Name of the creator. REQUIRED.</td>
+							<td>One or more Text.</td>
+							<td>
+								<a href="#value-array">Array</a> of <a href="#value-localizable-string">Localizable
+									Strings</a>
+							</td>
+							<td>
+								<a href="https://schema.org/name">
+									<code>name</code>
+								</a>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<code>
+									<dfn>id</dfn>
+								</code>
+							</td>
+							<td>A canonical identifier associated with the creator. OPTIONAL.</td>
+							<td>A URL record [[!url]].</td>
+							<td>
+								<a href="#value-id">Identifier</a>
+							</td>
+							<td> (None) </td>
+						</tr>
+						<tr>
+							<td>
+								<code>
+									<dfn>url</dfn>
+								</code>
+							</td>
+							<td>An address associated with the creator. OPTIONAL.</td>
+							<td>A valid URL string&#160;[[!url]].</td>
+							<td>
+								<a href="#value-url">URL</a>
+							</td>
+							<td>
+								<a href="https://schema.org/url">
+									<code>url</code>
+								</a>
+							</td>
+						</tr>
+					</tbody>
+				</table>
+
+				<p>Note that user agents MAY interpret a wider range of creator properties defined by Schema.org than
+					the ones in the preceding table.</p>
+
+				<pre class="idl">
+dictionary CreatorInfo {
+             sequence&lt;DOMString>         type;
+    required sequence&lt;LocalizableString> name;
+             DOMString                   id;
+             DOMString                   url;
+};
+</pre>
+			</section>
+
+			<section id="LocalizableString">
+				<h3><code>LocalizableString</code> Definition</h3>
+
+				<p id="localizablestring-link-def">This specification defines a new type for <a
+						href="#value-localizable-string">localizable strings</a> called <code><dfn
+							data-lt="localizable string">LocalizableString</dfn></code>. It consists of the following
+					properties:</p>
+
+				<table class="zebra" data-dfn-for="LocalizableString">
+					<thead>
+						<tr>
+							<th>Term</th>
+							<th>Description</th>
+							<th>Required Value</th>
+							<th>Value Type</th>
+							<th>[[!schema.org]] Mapping</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>
+								<code>
+									<dfn>value</dfn>
+								</code>
+							</td>
+							<td>The value of the localizable string. REQUIRED.</td>
+							<td>Text.</td>
+							<td></td>
+							<td>(None)</td>
+						</tr>
+						<tr>
+							<td>
+								<code>
+									<dfn>language</dfn>
+								</code>
+							</td>
+							<td>The language of the value. OPTIONAL.</td>
+							<td>A language code as defined in [[!bcp47]].</td>
+							<td><a href="#value-literal">Literal</a></td>
+							<td>(None)</td>
+						</tr>
+					</tbody>
+				</table>
+
+				<pre class="idl">
+dictionary LocalizableString {
+    required DOMString                   value;
+             DOMString                   language;
+};
+</pre>
+			</section>
 		</section>
 		<section id="app-toc-structure" class="appendix">
 			<h2>Machine-Processable Table of Contents</h2>
@@ -3785,16 +3888,16 @@ dictionary LinkedResource {
 			<section>
 				<h3>Simple Book</h3>
 				<p>A manifest for a simple book. The <a
-						href="https://w3c.github.io/pub-manifest/experiments/separate_manifest/mobydick.jsonld"
-						>canonical version</a> of this manifest is also available.</p>
+						href="https://w3c.github.io/pub-manifest/experiments/separate_manifest/mobydick.jsonld">JSON
+						encoding of its canonical representation</a> of this manifest is also available.</p>
 				<pre class="example" data-include="experiments/separate_manifest/mobydick-simple.jsonld" data-include-format="text"></pre>
 			</section>
 
 			<section>
 				<h3>Single-Document Publication</h3>
 				<p>Example for an embedded manifest example. The <a
-						href="https://w3c.github.io/pub-manifest/experiments/w3c_rec/simple-canonical.jsonld">canonical
-						version</a> of the manifest is, as well as a <a
+						href="https://w3c.github.io/pub-manifest/experiments/w3c_rec/simple-canonical.jsonld">JSON
+						encoding of its canonical representation</a> of the manifest is, as well as a <a
 						href="https://github.com/w3c/pub-manifest/blob/master/experiments/w3c_rec/full_version.html"
 						>more elaborate version</a> for the same document are also available.</p>
 				<pre class="example" data-include="experiments/w3c_rec/simple_version.html" data-include-format="text"></pre>
@@ -3803,73 +3906,12 @@ dictionary LinkedResource {
 			<section>
 				<h3>Audiobook</h3>
 				<p>A manifest for an audiobook. The <a
-						href="https://w3c.github.io/pub-manifest/experiments/audiobook/flatland-canonical.json"
-						>canonical version</a> of this manifest is also available.</p>
+						href="https://w3c.github.io/pub-manifest/experiments/audiobook/flatland-canonical.json">JSON
+						encoding of its canonical representation</a> of this manifest is also available.</p>
 				<pre class="example" data-include="experiments/audiobook/flatland.json" data-include-format="text"></pre>
 			</section>
 		</section>
 		<section id="app-bidi-examples" data-include="common/html/bidi-example-table.html" data-include-replace="true"></section>
-		<section id="app-lifecycle-diagrams" class="appendix informative">
-			<h2>Lifecycle diagrams</h2>
-
-			<p>These diagrams provide a visual view of the lifecycle steps, as specified in <a
-					href="#manifest-lifecycle"></a>.</p>
-
-			<section id="canonicalize-manifest-diagram">
-				<h3>Manifest canonicalization</h3>
-				<figure>
-					<object data="images/canonicalize_manifest.svg" type="image/svg+xml"
-						aria-describedby="canonicalize-manifest-diagram-descr">
-						<p id="canonicalize-manifest-diagram-descr">Second major block in the lifecyle algorithm: create
-							a canonical manifest (using the core manifest terms as examples)</p>
-					</object>
-					<figcaption> Second major block in the lifecyle algorithm: create a canonical manifest (using the
-						core manifest terms as examples).<br />See the normative description of the algorithm in <a
-							href="#canonical-manifest"></a>. Image available in <a
-							href="images/canonicalize_manifest.svg" title="SVG image of the canonicalization algorithm"
-							>SVG</a> and <a title="PNG SVG image of the canonicalization algorithm"
-							href="images/canonicalize_manifest.png">PNG</a> formats. </figcaption>
-				</figure>
-			</section>
-
-			<section id="convert-manifest-diagram">
-				<h3>Converting the manifest into a data structure</h3>
-				<figure>
-					<object data="images/convert_manifest.svg" type="image/svg+xml"
-						aria-describedby="convert-manifest-diagram-descr">
-						<p id="convert-manifest-diagram-descr">Third major block in the lifecyle algorithm: convert the
-							manifest into a programming language dependent data structure that implements the Web IDL
-							specification of the manifest.</p>
-					</object>
-					<figcaption> Third major block in the lifecyle algorithm: convert the manifest into a programming
-						language dependent data structure that implements the Web IDL specification of the
-						manifest.<br />See the normative description of the algorithm in <a
-							href="#post-processed-manifest"></a>. Image available in <a
-							href="images/convert_manifest.svg"
-							title="SVG image of converting the manifest into a data structure implementing the Web IDL representation"
-							>SVG</a> and <a
-							title="PNG image of converting the manifest into a data structure implementing the Web IDL representation"
-							href="images/convert_manifest.png">PNG</a> formats. </figcaption>
-				</figure>
-			</section>
-
-			<section id="clean-up-data-diagram">
-				<h3>Cleaning up the data</h3>
-				<figure>
-					<object data="images/clean_up_data.svg" type="image/svg+xml"
-						aria-describedby="cleanup-diagram-descr">
-						<p id="cleanup-diagram-descr">Fourth major block in the lifecyle algorithm: check and clean up
-							data by possibly removing data that cannot be interpreted.</p>
-					</object>
-					<figcaption> Fourth major block in the lifecyle algorithm: check and clean up data by possibly
-						removing data that cannot be interpreted.<br />See the normative description of the algorithm in
-							<a href="#post-processed-manifest"></a>. Image available in <a
-							href="images/clean_up_data.svg" title="SVG image on cleaning up the final data">SVG</a> and
-							<a title="PNG image on cleaning up the final data" href="images/clean_up_data.png">PNG</a>
-						formats. </figcaption>
-				</figure>
-			</section>
-		</section>
 		<section id="properties-index" class="appendix informative">
 			<h4>Properties Index</h4>
 
@@ -3922,12 +3964,6 @@ dictionary LinkedResource {
 						<td>
 							<a href="#accessibility"></a>
 						</td>
-					</tr>
-					<tr>
-						<td>
-							<code>address</code>
-						</td>
-						<td><a href="#address"></a></td>
 					</tr>
 					<tr>
 						<td>
@@ -4110,6 +4146,12 @@ dictionary LinkedResource {
 						<td>
 							<a href="#creators"></a>
 						</td>
+					</tr>
+					<tr>
+						<td>
+							<code>url</code>
+						</td>
+						<td><a href="#address"></a></td>
 					</tr>
 				</tbody>
 			</table>


### PR DESCRIPTION
This PR clarifies canonicalization and the processing algorithm as follows:
- removes section on authored and canonical manifests
- adds definition for canonical representation and switches "authored manifest" for "manifest"
- adds section on json-ld authoring and processing to manifest intro
- definitions of the value types are updated to use normative language for requirements
- the "manifest lifecycle" section is rewritten to a single algorithm using pseudo-code to express the resulting data instead of suggesting a final json-ld document
- the lifecycle diagrams are removed, at least for now, as they no longer reflect the specification

It also fixes the webidl as follows:
- id is changed from an array to a single value
- the definitions for CreatorInfo and LocalizableString are moved to appendixes and grouped with LinkedResource for consistency

Also removes reference to the publishing and linking note as we're no longer adopting terminology from it with the move away from WP.

Also some minor editorial cleanup.

These changes were agreed to in previous issues and calls, so once we resolve any feedback it would be good to merge this as soon as possible so it doesn't block the other ongoing work.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/44.html" title="Last updated on Aug 27, 2019, 10:36 AM UTC (fbb2c8a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/44/92c505c...fbb2c8a.html" title="Last updated on Aug 27, 2019, 10:36 AM UTC (fbb2c8a)">Diff</a>