### PR TITLE
Add type property defs to LinkedResource and LocalizableString

### DIFF
--- a/index.html
+++ b/index.html
@@ -1511,7 +1511,7 @@ enum ProgressionDirection {
 
 					<section id="language-and-dir">
 						<h5>Publication Language and Base Direction</h5>
-						
+
 						<p>A <a>digital publication</a> has at least one natural language, which is the language that
 							the content is expressed in (e.g., English, French, Chinese). It also has a natural base
 							direction in which it is written — the display direction, either left-to-right or
@@ -3041,6 +3041,19 @@ enum ProgressionDirection {
 						<tr>
 							<td>
 								<code>
+									<dfn>type</dfn>
+								</code>
+							</td>
+							<td>The type of resource. OPTIONAL</td>
+							<td>One or more Text. Sequence MUST include "<code>LinkedResource</code>".</td>
+							<td>
+								<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
+							</td>
+							<td>(None)</td>
+						</tr>
+						<tr>
+							<td>
+								<code>
 									<dfn>url</dfn>
 								</code>
 							</td>
@@ -3179,6 +3192,7 @@ enum ProgressionDirection {
 
 				<pre class="idl">
 dictionary LinkedResource {
+             sequence&lt;DOMString> type;
     required DOMString           url;
              DOMString           encodingFormat;
              sequence&lt;LocalizableString>   name;
@@ -3213,7 +3227,7 @@ dictionary LinkedResource {
 								</code>
 							</td>
 							<td>The type of creator. OPTIONAL</td>
-							<td>One or more Text. Sequence should include "<code>Person</code>" or
+							<td>One or more Text. Sequence MUST include "<code>Person</code>" or
 									"<code>Organization</code>".</td>
 							<td>
 								<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
@@ -3306,6 +3320,19 @@ dictionary CreatorInfo {
 						<tr>
 							<td>
 								<code>
+									<dfn>type</dfn>
+								</code>
+							</td>
+							<td>The type of string. OPTIONAL</td>
+							<td>One or more Text. Sequence MUST include "<code>LocalizableString</code>".</td>
+							<td>
+								<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
+							</td>
+							<td>(None)</td>
+						</tr>
+						<tr>
+							<td>
+								<code>
 									<dfn>value</dfn>
 								</code>
 							</td>
@@ -3330,6 +3357,7 @@ dictionary CreatorInfo {
 
 				<pre class="idl">
 dictionary LocalizableString {
+             sequence&lt;DOMString>         type;
     required DOMString                   value;
              DOMString                   language;
 };


### PR DESCRIPTION
Fixes #35.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/50.html" title="Last updated on Aug 31, 2019, 3:58 PM UTC (451fb58)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/50/90c168d...451fb58.html" title="Last updated on Aug 31, 2019, 3:58 PM UTC (451fb58)">Diff</a>