### PR TITLE
Editorial cleanup

### DIFF
--- a/common/html/bidi-example-table.html
+++ b/common/html/bidi-example-table.html
@@ -1,47 +1,98 @@
-<section id="app-bidi-examples" class="appendix informative">
-	<h2>Examples for bidirectional texts</h2>
+<section id="app-bidi" class="appendix">
+	<h2>Bidirectional Texts</h2>
 
-	<p>This section illustrates how Unicode formatting characters can be applied to bidirectional strings, where necessary, in order to help a consumer produce the expected display. In cases where the first-strong heuristics would produce the wrong result, if the string is created with a prepended formatting character, the first-strong heuristics will produce the correct base direction for the string as a whole.</p>
+	<section id="app-bidi-directionality">
+		<h3>Item-Specific Directionality in JSON-LD</h3>
 
-	<p>A right-to-left string that begins with a Latin script character should have U+200F RIGHT-TO-LEFT MARK prepended.</p>
+		<p>Setting the direction for a natural text value is currently not possible in JSON-LD&#160;[[json-ld]]. In
+			order to correctly handle manifests entries containing right-to-left or bidirectional text, user agents
+			SHOULD identify the base direction of any given natural language value by scanning the text for the first
+			strong directional character.</p>
 
-	<table>
-		<tr>
-			<td>Character order in memory:&nbsp;</td>
-			<td><code><bdo dir="ltr">HTML היא שפת סימון.</bdo></code></td>
-		</tr>
-		<tr>
-			<td>Gives incorrect display:&nbsp;</td>
-			<td dir="ltr">HTML היא שפת סימון.</td>
-		</tr>
-		<tr>
-			<td>Source code with formatting character:&nbsp;</td>
-			<td><code>"<bdo dir="ltr">\u200FHTML היא שפת סימון.</bdo>"</code></td>
-		</tr>
-		<tr>
-			<td>Gives expected display:&nbsp;</td>
-			<td dir="rtl">HTML היא שפת סימון.</td>
-		</tr>
-	</table>
+		<p>In situations where the first-strong heuristics will produce the wrong result (e.g., a string in the Arabic
+			or Hebrew script that begins with a Latin acronym), authors can prepend a Unicode formatting character (one
+			of U+200E LEFT-TO-RIGHT MARK or U+200F RIGHT-TO-LEFT MARK) to the string. This would then produce the
+			necessary base direction when the heuristics are applied. (See <a href="#app-bidi-examples"/>.)</p>
 
-	<p>A left-to-right string that begins with a Arabic script character should have U+200E LEFT-TO-RIGHT MARK prepended.</p>
+		<p>Once the base direction has been identified, user agents MUST determine the appropriate rendering and display
+			of natural language values according to the Unicode Bidirectional Algorithm&#160;[[!bidi]]. This could
+			require wrapping additional markup or Unicode formatting characters around the string prior to display, in
+			order to apply the base direction.</p>
 
-	<table>
-		<tr>
-			<td>Character order in memory:&nbsp;</td>
-			<td><code><bdo dir="ltr">'سلام' is hello in Persian.</bdo></code></td>
-		</tr>
-		<tr>
-			<td>Gives incorrect display:&nbsp;</td>
-			<td dir="rtl">'سلام' is hello in Persian.</td>
-		</tr>
-		<tr>
-			<td>Source code with formatting character:&nbsp;</td>
-			<td><code>"<bdo dir="ltr">\u200E'سلام' is hello in Persian.</bdo>"</code></td>
-		</tr>
-		<tr>
-			<td>Gives expected display:&nbsp;</td>
-			<td dir="ltr">'سلام' is hello in Persian.</td>
-		</tr>
-	</table>	
+		<p class="note">If authors intend to use a manifest, or a manifest template, both as embedded manifest and as a
+			separate resource, they are strongly encouraged to set these properties explicitly to avoid interference of
+			the containing <code>script</code> element in case of embedding.</p>
+
+		<aside class="note">
+			<p>Future versions of this specification could extend the ability of manifests to identify item-specific
+				directionality if the JSON-LD and schema.org communities introduce such a feature.</p>
+
+			<p>For more information about localized strings on the Web, refer to [[string-meta]].</p>
+		</aside>
+	</section>
+
+	<section id="app-bidi-examples" class="informative">
+		<h3>Bidirectional Text Examples</h3>
+
+		<p>This section illustrates how Unicode formatting characters can be applied to bidirectional strings, where
+			necessary, in order to help a consumer produce the expected display. In cases where the first-strong
+			heuristics would produce the wrong result, if the string is created with a prepended formatting character,
+			the first-strong heuristics will produce the correct base direction for the string as a whole.</p>
+
+		<p>A right-to-left string that begins with a Latin script character should have U+200F RIGHT-TO-LEFT MARK
+			prepended.</p>
+
+		<table>
+			<tr>
+				<td>Character order in memory:&nbsp;</td>
+				<td>
+					<code>
+						<bdo dir="ltr">HTML היא שפת סימון.</bdo>
+					</code>
+				</td>
+			</tr>
+			<tr>
+				<td>Gives incorrect display:&nbsp;</td>
+				<td dir="ltr">HTML היא שפת סימון.</td>
+			</tr>
+			<tr>
+				<td>Source code with formatting character:&nbsp;</td>
+				<td>
+					<code>"<bdo dir="ltr">\u200FHTML היא שפת סימון.</bdo>"</code>
+				</td>
+			</tr>
+			<tr>
+				<td>Gives expected display:&nbsp;</td>
+				<td dir="rtl">HTML היא שפת סימון.</td>
+			</tr>
+		</table>
+
+		<p>A left-to-right string that begins with a Arabic script character should have U+200E LEFT-TO-RIGHT MARK
+			prepended.</p>
+
+		<table>
+			<tr>
+				<td>Character order in memory:&nbsp;</td>
+				<td>
+					<code>
+						<bdo dir="ltr">'سلام' is hello in Persian.</bdo>
+					</code>
+				</td>
+			</tr>
+			<tr>
+				<td>Gives incorrect display:&nbsp;</td>
+				<td dir="rtl">'سلام' is hello in Persian.</td>
+			</tr>
+			<tr>
+				<td>Source code with formatting character:&nbsp;</td>
+				<td>
+					<code>"<bdo dir="ltr">\u200E'سلام' is hello in Persian.</bdo>"</code>
+				</td>
+			</tr>
+			<tr>
+				<td>Gives expected display:&nbsp;</td>
+				<td dir="ltr">'سلام' is hello in Persian.</td>
+			</tr>
+		</table>
+	</section>
 </section>

--- a/index.html
+++ b/index.html
@@ -363,7 +363,7 @@ enum ProgressionDirection {
 
 				<ol>
 					<li>the [[!schema.org]] context: <code>https://schema.org</code></li>
-					<li>the publication context: <code>https://www.w3.org/ns/pub-context</code></li>
+					<li>the <dfn>publication context</dfn>: <code>https://www.w3.org/ns/pub-context</code></li>
 				</ol>
 
 				<pre class="example" title="The context declaration.">
@@ -392,10 +392,10 @@ enum ProgressionDirection {
 					Chinese). It also has a natural <dfn>base direction</dfn> in which it is written — the display
 					direction, either left-to-right or right-to-left.</p>
 
-				<p>The digital publication manifest includes entries to set both these concepts &#8212; both <a
-						href="#manifest-lang-dir-global">globally</a> and for <a href="#manifest-lang-dir-local"
-						>individual items</a> &#8212; to aid user agents in interpreting and presenting the
-					metadata.</p>
+				<p>The digital publication manifest provides the ability to set both these concepts <a
+						href="#manifest-lang-dir-global">globally</a> &#8212; and, for language, on <a
+						href="#manifest-lang-dir-local">individual items</a> &#8212; to aid user agents in interpreting
+					and presenting the metadata.</p>
 
 				<section id="manifest-lang-dir-global">
 					<h4>Global Declarations</h4>
@@ -424,8 +424,10 @@ enum ProgressionDirection {
 							href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
 						tag</a>&#160;[[!bcp47]].</p>
 
-					<p>The global language declaration MUST follow the <a href="#manifest-context">publication
-							context</a> when present.</p>
+					<p class="ednote">There is an open issue to determine whether it is better to require valid or
+						well-formed language tags.</p>
+
+					<p>The global language declaration, when present, MUST follow the <a>publication context</a>.</p>
 
 					<p>Unlike the default language, the default text direction cannot be specified in the context as
 						JSON-LD does not currently include facilities for this. As an interim measure, this
@@ -512,37 +514,8 @@ enum ProgressionDirection {
 					<p>In such cases, the local declaration takes precedence over the <a
 							href="#manifest-lang-dir-global">global declaration</a>.</p>
 
-					<p>It is <em>not</em> possible to set the direction explicitly for a specific value.</p>
-
-					<div class="note">
-						<p>Setting the direction for a natural text value is currently not possible in
-							JSON-LD&#160;[[json-ld]]. In case the JSON-LD community, as well as the schema.org
-							community, introduces such a feature, future versions of this specification may extend the
-							ability of manifests to include this.</p>
-
-
-						<p>For more information about localized strings on the Web, refer to [[string-meta]].</p>
-					</div>
-
-					<p>In order to correctly handle manifests entries containing right-to-left or bidirectional text,
-						user agents SHOULD identify the base direction of any given natural language value by scanning
-						the text for the first strong directional character.</p>
-
-					<p class="note">In situations where the first-strong heuristics will produce the wrong result (e.g.,
-						a string in the Arabic or Hebrew script that begins with a Latin acronym), authors can prepend a
-						Unicode formatting character (one of U+200E LEFT-TO-RIGHT MARK or U+200F RIGHT-TO-LEFT MARK) to
-						the string. This would then produce the necessary base direction when the heuristics are
-						applied. (See <a href="#app-bidi-examples"></a>.)</p>
-
-					<p>Once the base direction has been identified, user agents MUST determine the appropriate rendering
-						and display of natural language values according to the Unicode Bidirectional
-						Algorithm&#160;[[!bidi]]. This could require wrapping additional markup or Unicode formatting
-						characters around the string prior to display, in order to apply the base direction.</p>
-
-					<p class="note">If authors intend to use a manifest, or a manifest template, both as embedded
-						manifest and as a separate resource, they are strongly encouraged to set these properties
-						explicitly to avoid interference of the containing <code>script</code> element in case of
-						embedding.</p>
+					<p class="note">It is <em>not</em> possible to set the direction explicitly for a specific value.
+						For more information, refer to <a href="#app-bidi-directionality"></a>.</p>
 				</section>
 			</section>
 
@@ -1592,10 +1565,11 @@ enum ProgressionDirection {
 								>well-formed language tag</a> &#160;[[!bcp47]].</p>
 
 						<p>If a user agent requires the publication language and it is not available in the manifest, or
-							the obtained value is invalid, the user agent MAY attempt to determine the publication
-							language when <a href="#manifest-processing">generating its canonical representation</a>.
-							This specification does not mandate how such a language tag is created. The user agent
-							might:</p>
+							the obtained value is not <a href="https://tools.ietf.org/html/bcp47#section-2.2.9"
+								>well-formed</a>&#160;[[!bcp47]], the user agent MAY attempt to determine the
+							publication language when <a href="#manifest-processing">generating its canonical
+								representation</a>. This specification does not mandate how such a language tag is
+							created. The user agent might:</p>
 
 						<ul>
 							<li>use the <a>non-empty</a>
@@ -2912,8 +2886,9 @@ enum ProgressionDirection {
 						<li id="processing-checks-language">
 							<p>(<a href="#manifest-lang-dir-global"></a> and <a href="#manifest-lang-dir-local"></a>)
 								Recursively check that every <var>language</var> property in <var>processed</var> is <a
-									href="https://tools.ietf.org/html/bcp47#section-2.2.9">valid</a>&#160;[[!bcp47]] and
-								issue a warning for any invalid values found.</p>
+									href="https://tools.ietf.org/html/bcp47#section-2.2.9"
+								>well-formed</a>&#160;[[!bcp47]] and issue a warning for any non well-formed values
+								found.</p>
 						</li>
 
 						<li id="processing-checks-direction">
@@ -2947,8 +2922,9 @@ enum ProgressionDirection {
 						<li id="processing-checks-inlanguage">
 							<p>(<a href="#language-and-dir"></a>) If <var>processed["inLanguage"]</var> is set, check
 								that each value in its array is <a
-									href="https://tools.ietf.org/html/bcp47#section-2.2.9">valid</a>&#160;[[!bcp47]] and
-								issue a warning for any invalid values found.</p>
+									href="https://tools.ietf.org/html/bcp47#section-2.2.9"
+								>well-formed</a>&#160;[[!bcp47]] and issue a warning for any non well-formed values
+								found.</p>
 						</li>
 
 						<li id="processing-checks-progression-dir">

--- a/index.html
+++ b/index.html
@@ -144,17 +144,16 @@
 					<h4>Manifest Format</h4>
 
 					<p>A <a>digital publication</a> is described by its <a>manifest</a>, which provides a set of
-						properties expressed using a specific shape of JSON-LD&#160;[[json-ld]] format (a variant of
+						properties expressed using a specific shape of JSON-LD&#160;[[json-ld]] (a variant of
 						JSON&#160;[[ecma-404]] for linked data).</p>
 
-					<p>A <a>digital publication's</a>
-						<a>manifest</a> is defined by a set of properties that describe the basic information a user
-						agent requires to process and render the publication. For ease of understanding, these
-						properties are categorized as follows:</p>
+					<p>The properties of the manifest describe the basic information a user agent requires to process
+						and render a publication. For ease of understanding, these properties are categorized as
+						follows:</p>
 
 					<dl>
 						<dt>
-							<a href="#descriptive-properties">descriptive properties</a>
+							<a href="#descriptive-properties">Descriptive properties</a>
 						</dt>
 						<dd>
 							<p>Descriptive properties describe aspects of a digital publication, such as its <a
@@ -162,13 +161,41 @@
 									href="#language-and-dir">language</a>.</p>
 						</dd>
 						<dt>
-							<a href="#resource-categorization-properties">resource categorization</a>
+							<a href="#resource-categorization-properties">Resource categorization properties</a>
 						</dt>
 						<dd>
 							<p>Resource categorization properties describe or identify common sets of resources, such as
 								the <a href="#resource-list">resource list</a> and <a href="#default-reading-order"
 									>default reading order</a>. These properties refer to one or more resources, such as
-								HTML documents, images, script files, and separate metadata files.</p>
+								HTML documents, images, scripts, and metadata records.</p>
+						</dd>
+					</dl>
+
+					<p>The <a>manifest</a> also identifies key resources of a digital publication through the use of
+						link relations. These relations are applied to the <a href="#dom-linkedresource-rel"
+								><code>rel</code> property</a> of <a href="#LinkedResource"><code>LinkedResource</code>
+							objects</a> (e.g., the links found in the <a href="#pub-table-of-contents">table of
+							contents</a> and <a href="#resource-list">resource list</a>).</p>
+
+					<p>The types of resources these relations identify are categorized as follows:</p>
+
+					<dl>
+						<dt>
+							<a href="#informative-rel">informative resources</a>
+						</dt>
+						<dd>
+							<p>Informative resources are resources that contain additional information about the
+								publication, such as its <a href="#privacy-policy">privacy policy</a>, <a
+									href="#accessibility-report">accessibility report</a>, or <a href="#preview"
+									>preview</a>.</p>
+						</dd>
+						<dt>
+							<a href="#structural-rel">structural resources</a>
+						</dt>
+						<dd>
+							<p>Structural resources are key meta structures of the publication, such as the <a
+									href="#cover">cover image</a>, <a href="#table-of-contents">table of contents</a>,
+								and <a href="#page-list">page list</a>.</p>
 						</dd>
 					</dl>
 
@@ -180,8 +207,8 @@
 					<h4>JSON-LD Authoring and Processing</h4>
 
 					<p>This specification defines the publication manifest as a specific "shape" of [[!json-ld]]. This
-						means that the manifest SHOULD be expressed using only the syntactical constructions as defined
-						in this specification, as opposed to all the possibilities offered by the JSON-LD syntax.</p>
+						means that the manifest SHOULD be expressed using only the syntactic constructions defined in
+						this specification, as opposed to all the possibilities offered by the JSON-LD syntax.</p>
 
 					<p class="note">This shape is also defined, informally, through a JSON schema&#160;[[json-schema]]
 						that expresses the constraints defined in this specification. This schema is maintained at <a
@@ -202,24 +229,28 @@
 				<section id="manifest-schemaorg">
 					<h4>Relationship to Schema.org</h4>
 
-					<p>Manifest properties are primarily drawn from <a href="https://schema.org">schema.org</a> and its
-							<a href="https://schema.org/docs/schemas.html">hosted extensions</a>&#160;[[schema.org]], in
-						particular those categorized as <a href="#descriptive-properties">descriptive properties</a>. As
-						a consequence, these properties inherit their syntax and semantics from schema.org, making
-						manifest authoring compatible with Schema.org authoring.</p>
+					<p>Manifest properties, in particular those categorized as <a href="#descriptive-properties"
+							>descriptive properties</a>, are primarily drawn from <a href="https://schema.org"
+							>schema.org</a> and its <a href="https://schema.org/docs/schemas.html">hosted
+						extensions</a>&#160;[[!schema.org]]. As a consequence, these properties inherit their syntax and
+						semantics from schema.org, making manifest authoring compatible with schema.org authoring.</p>
 
 					<p>When a manifest item corresponds to a schema.org property, its <a href="#manifest-properties"
-							>property definition</a> table identifies its mapping and includes the defining type (e.g.,
-							<a href="https://schema.org/CreativeWork">CreativeWork</a> or <a
-							href="https://schema.org/Book">Book</a>) in parentheses. Properties are often available in
-						many types, however, as a result of the schema.org inheritance model. Refer to each property
-						definition for more detailed information about where it is valid to use.</p>
+							>property definition</a> identifies its mapping and includes the defining type (e.g., <a
+							href="https://schema.org/CreativeWork">CreativeWork</a> or <a href="https://schema.org/Book"
+							>Book</a>) in parentheses.</p>
 
 					<p>Schema.org additionally includes a large number of properties that, though relevant for
 						publishing, are not mentioned in this specification. These properties MAY be used in a manifest
 						as this document defines only the minimal set of manifest items.</p>
 
-					<p>For more information about using additional schema.org properties, refer to <a
+					<p>When using additional schema.org properties, ensure that they are valid for the <a
+							href="#publication-types">type of publication</a> specified in the manifest. Properties are
+						often available in many schema.org types, as a result of the inheritance model used by the
+						vocabulary, but not all properties are available for all types. For more detailed information
+						about which types accept which properties, refer to [[!schema.org]].</p>
+
+					<p>More information about using additional schema.org properties is also available in <a
 							href="#publication-types"></a> and <a href="#extensibility-manifest-properties"></a></p>
 				</section>
 			</section>
@@ -227,7 +258,7 @@
 			<section id="manifest-requirements">
 				<h5>Requirements</h5>
 
-				<p>All implementations of the a <a>digital publication</a> manifest MUST set the following:</p>
+				<p>The following properties MUST be set in the manifest:</p>
 
 				<ul>
 					<li>
@@ -236,21 +267,14 @@
 					<li>
 						<a href="#publication-types">type</a>
 					</li>
-					<li>
-						<a href="#default-reading-order">default reading order</a>
-					</li>
-					<li>
-						<a href="#pub-title">title</a>
-					</li>
 				</ul>
-
-				<p class="note">Not all of these properties have to be serialized in the manifest. Refer to each
-					property's definition to determine whether, and how, it is compiled into the <a>canonical
-						representation</a> from other information.</p>
 
 				<p>The priority of all other <a href="#manifest-properties">properties</a> and <a href="#manifest-rel"
 						>resource relations</a> is OPTIONAL, but MAY be modified by implementations of the manifest
 					format.</p>
+
+				<p class="note">Some properties are implicitly required, as they are compiled from alternative
+					information when not explicitly authored. See <a href="#webidl"></a> for more information.</p>
 			</section>
 
 			<section id="webidl">
@@ -262,12 +286,19 @@
 
 				<p>To simplify the manifest format for developers, this specification defines an abstract representation
 					of the data structures employed by the manifest using the Web Interface Definition Language (Web
-					IDL) [[!webidl-1]] — <a href="#webidl-wpm">the <code>PublicationManifest</code> dictionary</a>.</p>
+					IDL)&#160;[[!webidl-1]] — <a href="#webidl-wpm">the <code>PublicationManifest</code>
+					dictionary</a>.</p>
 
 				<p>This definition expresses the expected names, datatypes, and possible restrictions for each member of
 					the manifest. Unlike a typical Web IDL definition, however, user agents are not expected to expose
 					the information in the manifest as an API. The Web IDL language is chosen solely to provide an
 					abstraction of the data model.</p>
+
+				<p>The required members of the <code>PublicationManifest</code> dictionary do not exactly match <a
+						href="#manifest-requirements">the required members of the manifest</a> as user agents are
+					expected to compile information from other sources in the absence of an explicit declaration for
+					some properties (e.g., for the <a href="#pub-title">title</a> and <a href="#default-reading-order"
+						>reading order</a>).</p>
 
 				<p class="note">It is not necessary to understand the Web IDL definition in order to create digital
 					publications. Authoring requirements are defined in the following sections.</p>
@@ -327,8 +358,8 @@ enum ProgressionDirection {
 			<section id="manifest-context">
 				<h3>Manifest Contexts</h3>
 
-				<p>A <a>manifest</a> MUST set its JSON-LD context [[!json-ld]] with the following two components, in the
-					specified order:</p>
+				<p>A <a>manifest</a> MUST set its JSON-LD context&#160;[[!json-ld]] with the following two components,
+					in the specified order:</p>
 
 				<ol>
 					<li>the [[!schema.org]] context: <code>https://schema.org</code></li>
@@ -346,55 +377,60 @@ enum ProgressionDirection {
 					requirement for the <a href="https://schema.org/creator">creator</a> property to be order
 					preserving).</p>
 
-				<p class="ednote">As part of the continuous contacts with Schema.org the additional features defined in
-					the publication context file could migrate to the core Schema.org vocabulary.</p>
-
-				<p class="note">Although Schema.org is often referenced using the <code>http</code> URI scheme, <a
+				<p>Although Schema.org is often referenced using the <code>http</code> URI scheme, <a
 						href="https://schema.org/docs/faq.html#19">the vocabulary is being migrated</a> to use the
-					secure <code>https</code> scheme as its default. This specification requires the use of
-						<code>https</code> when referencing Schema.org in the manifest.</p>
+					secure <code>https</code> scheme as its default. The use of <code>https</code> when referencing
+					Schema.org in the manifest is REQUIRED by this specification.</p>
 			</section>
 
 			<section id="manifest-lang-dir">
 				<h3>Manifest Language and Direction</h3>
 
-				<p>Each natural language property value in a manifest (e.g., <a href="#pub-title">title</a>, <a
-						href="#creators">creators</a>) has a default natural <dfn>language</dfn>, which is the language
-					that it is expressed in (e.g., English, French, Chinese). It also has a natural <dfn>base
-						direction</dfn> in which it is written — the display direction, either left-to-right or
-					right-to-left.</p>
+				<p>Each <a href="#value-localizable-string">natural language property value</a> in a manifest (e.g., <a
+						href="#pub-title">title</a>, <a href="#creators">creators</a>) has a default natural
+						<dfn>language</dfn>, which is the language that it is expressed in (e.g., English, French,
+					Chinese). It also has a natural <dfn>base direction</dfn> in which it is written — the display
+					direction, either left-to-right or right-to-left.</p>
 
-				<p>The digital publication manifest includes entries to set both these concepts to aid user agents in
-					interpreting and presenting the metadata.</p>
+				<p>The digital publication manifest includes entries to set both these concepts &#8212; both <a
+						href="#manifest-lang-dir-global">globally</a> and for <a href="#manifest-lang-dir-local"
+						>individual items</a> &#8212; to aid user agents in interpreting and presenting the
+					metadata.</p>
 
 				<section id="manifest-lang-dir-global">
 					<h4>Global Declarations</h4>
 
-					<p>The default language is set by including a language declaration in the context using the <a
+					<p>The default language for natural language manifest properties is set by including a global
+						language declaration in the context using the <a
 							href="https://w3c.github.io/json-ld-syntax/#syntax-tokens-and-keywords"
-								><code>language</code> key</a> [[!json-ld]]:</p>
+								><code>language</code> keyword</a>&#160;[[!json-ld]]. It is used to expand simple string
+						values into <a href="#value-localizable-string">localizable strings</a> during the <a
+							href="#manifest-processing">processing of the manifest</a>, as well as to provide a language
+						for localizable strings that omit one.</p>
+
 
 					<aside class="example" title="Declaring French as the default language for the manifest">
 						<pre><code>{
-    "@context" : [
+    "@context": [
         "https://schema.org",
         "https://www.w3.org/ns/pub-context", 
         {"language":"fr"}
     ],
-    "name" : "Le roi René"
+    &#8230;
 }</code></pre>
 					</aside>
+
+					<p>The value of <code>language</code> MUST be a <a
+							href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
+						tag</a>&#160;[[!bcp47]].</p>
 
 					<p>The global language declaration MUST follow the <a href="#manifest-context">publication
 							context</a> when present.</p>
 
-					<p>The value of the <code>language</code> MUST be set to a language code that is well-formed as
-						defined in [[!bcp47]].</p>
-
-					<p>Unlike the default language, the default direction of the text cannot be specified in the context
-						as JSON-LD does not currently include facilities for this. As an interim measure, this
-						specification defines a <code>direction</code> property for this purpose, as described in the
-						following table.</p>
+					<p>Unlike the default language, the default text direction cannot be specified in the context as
+						JSON-LD does not currently include facilities for this. As an interim measure, this
+						specification defines a <code>direction</code> property for defining the global text
+						direction.</p>
 
 					<table class="zebra">
 						<thead>
@@ -414,7 +450,7 @@ enum ProgressionDirection {
 									</code>
 								</td>
 								<td>Default <a>base direction</a> for textual manifest values</td>
-								<td><code>ltr</code>, <code>rtl</code>, or <code>auto</code></td>
+								<td>One of: <code>ltr</code>, <code>rtl</code>, or <code>auto</code>.</td>
 								<td>
 									<a href="#value-literal">Literal</a>
 								</td>
@@ -431,19 +467,28 @@ enum ProgressionDirection {
 							set to left-to-right text;</li>
 						<li><code><dfn>rtl</dfn></code>: indicates that the textual values are explicitly directionally
 							set to right-to-left text;</li>
-						<li><code><dfn>auto</dfn></code> indicates that the textual values are explicitly directionally
+						<li><code><dfn>auto</dfn></code>: indicates that the textual values are explicitly directionally
 							set to the direction of the first character with a strong directionality, following the
-							rules of the Unicode Bidirectional Algorithm [[!bidi]].</li>
+							rules of the Unicode Bidirectional Algorithm&#160;[[!bidi]].</li>
 					</ul>
 
-					<p>No default values are specified for the global language or base direction.</p>
+					<pre class="example" title="Setting the global text directionality to right-to-left">{
+    "@context" : [
+        "https://schema.org",
+        "https://www.w3.org/ns/pub-context", 
+        {"language":"he"}
+    ],
+    "direction" : "rtl"
+}</pre>
+
+					<p>Default values are not specified for the global language and base direction declarations.</p>
 				</section>
 
 				<section id="manifest-lang-dir-local">
 					<h4>Item-Specific Declarations</h4>
 
-					<p>It is possible to set the language locally for any textual value in the manifest using a <a
-							href="#LocalizableString">localizable string</a>:</p>
+					<p>It is possible to set the language locally for any natural language value in the manifest using a
+							<a href="#LocalizableString">localizable string</a>:</p>
 
 					<pre class="example" title="Setting the author name to French using a localizable string">
 {
@@ -459,50 +504,35 @@ enum ProgressionDirection {
     }
 }
 </pre>
-					<p>The value of the <code>language</code> MUST be set to a language code that is well-formed as
-						defined in [[!bcp47]].</p>
+					<p>The value of the <a href="https://w3c.github.io/json-ld-syntax/#syntax-tokens-and-keywords"
+								><code>language</code> keyword</a>&#160;[[!json-ld]] MUST be a <a
+							href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
+						tag</a>&#160;[[!bcp47]].</p>
 
-					<p>When used in a context of localizable texts, a simple string value is a shorthand for a
-							<a>localizable string</a>, with the <code>value</code> set to the string value, and the
-						language set to the value of the <a href="#manifest-lang-dir-global">default
-								<code>language</code> property</a>, if applicable, and unset otherwise. In other words,
-						the previous example is equivalent to:</p>
-
-					<pre class="example" title="Setting the default language of an author name to French">
-{
-    "@context"   : [
-        "https://schema.org",
-        "https://www.w3.org/ns/pub-context",
-        {"language": "fr"}
-    ],
-    "type"       : "Book",
-    &#8230;
-    "author"     : "Marcel Proust",
-    &#8230;	
-}
-</pre>
-					<p>See <a href="#value-objects"></a> for more information.</p>
+					<p>In such cases, the local declaration takes precedence over the <a
+							href="#manifest-lang-dir-global">global declaration</a>.</p>
 
 					<p>It is <em>not</em> possible to set the direction explicitly for a specific value.</p>
 
-					<p class="note">For more information about localized strings on the Web, refer to
-						[[string-meta]].</p>
+					<div class="note">
+						<p>Setting the direction for a natural text value is currently not possible in
+							JSON-LD&#160;[[json-ld]]. In case the JSON-LD community, as well as the schema.org
+							community, introduces such a feature, future versions of this specification may extend the
+							ability of manifests to include this.</p>
 
-					<p class="note">Setting the direction for a natural text value is currently not possible in
-						JSON-LD&#160;[[json-ld]]. In case the JSON-LD community, as well as the schema.org community,
-						introduces such a feature, future versions of this specification may extend the ability of
-						manifests to include this.</p>
+
+						<p>For more information about localized strings on the Web, refer to [[string-meta]].</p>
+					</div>
 
 					<p>In order to correctly handle manifests entries containing right-to-left or bidirectional text,
 						user agents SHOULD identify the base direction of any given natural language value by scanning
 						the text for the first strong directional character.</p>
 
 					<p class="note">In situations where the first-strong heuristics will produce the wrong result (e.g.,
-						a string in the Arabic or Hebrew script that begins with a Latin acronym), content developers
-						may want to prepend a Unicode formatting character to the string. This would then produce the
-						necessary base direction when the heuristics are applied. They should use one of the following
-						formatting characters: U+200E LEFT-TO-RIGHT MARK, or U+200F RIGHT-TO-LEFT MARK. (See <a
-							href="#app-bidi-examples"></a>.)</p>
+						a string in the Arabic or Hebrew script that begins with a Latin acronym), authors can prepend a
+						Unicode formatting character (one of U+200E LEFT-TO-RIGHT MARK or U+200F RIGHT-TO-LEFT MARK) to
+						the string. This would then produce the necessary base direction when the heuristics are
+						applied. (See <a href="#app-bidi-examples"></a>.)</p>
 
 					<p>Once the base direction has been identified, user agents MUST determine the appropriate rendering
 						and display of natural language values according to the Unicode Bidirectional
@@ -521,9 +551,10 @@ enum ProgressionDirection {
 
 				<p>A <a>digital publication's</a>
 					<a>manifest</a> defines its <dfn>Publication Type</dfn> using the <code
-						data-dfn-for="PublicationManifest"><dfn>type</dfn></code> term&#160;[[!json-ld]]. The type MAY
-					be mapped onto <a href="https://schema.org/CreativeWork"
-					><code>CreativeWork</code></a>&#160;[[!schema.org]].</p>
+						data-dfn-for="PublicationManifest"><dfn>type</dfn></code> keyword&#160;[[!json-ld]]. The type
+					MAY be mapped onto any [[!schema.org]] type, but <a href="https://schema.org/CreativeWork"
+							><code>CreativeWork</code></a> is <a href="#processing-checks-type">assumed as the
+						default</a> when no type is specified.</p>
 
 				<pre class="example" title="Setting a publication's type to CreativeWork.">
 {
@@ -533,11 +564,11 @@ enum ProgressionDirection {
 }
 </pre>
 
-				<p>Schema.org also includes a number of more specific subtypes of <code>CreativeWork</code>, such as <a
-						href="https://schema.org/Article"><code>Article</code></a>, <a href="https://schema.org/Book"
-							><code>Book</code></a>, <a href="https://schema.org/TechArticle"
-						><code>TechArticle</code></a>, and <a href="https://schema.org/Course"><code>Course</code></a>.
-					These MAY be used instead of, or in addition to, <code>CreativeWork</code>.</p>
+				<p>More specific subtypes of <code>CreativeWork</code>, such as <a href="https://schema.org/Article"
+							><code>Article</code></a>, <a href="https://schema.org/Book"><code>Book</code></a>, <a
+						href="https://schema.org/TechArticle"><code>TechArticle</code></a>, and <a
+						href="https://schema.org/Course"><code>Course</code></a> can be used instead of, or in addition
+					to, <code>CreativeWork</code>.</p>
 
 				<pre class="example" title="Setting a publication's type to Book.">
 {
@@ -547,8 +578,8 @@ enum ProgressionDirection {
 }
 </pre>
 
-				<p>Each Schema.org type defines a set of properties that are valid for use with it. To ensure that the
-					manifest can be validated and processed by Schema.org aware processors, the manifest SHOULD contain
+				<p>Each schema.org type defines a set of properties that are valid for use with it. To ensure that the
+					manifest can be validated and processed by schema.org-aware processors, the manifest SHOULD contain
 					only the properties associated with the selected type.</p>
 
 				<p>If properties from more than one type are needed, the manifest MAY include multiple type
@@ -562,11 +593,12 @@ enum ProgressionDirection {
 }
 </pre>
 
-				<p>User agents SHOULD NOT fail to process manifests that are not valid to their declared Schema.org
+				<p>User agents SHOULD NOT fail to process manifests that are not valid to their declared schema.org
 					type(s).</p>
 
-				<p class="note">Refer to the Schema.org site for the complete <a href="https://schema.org/CreativeWork"
-						>list of <code>CreativeWork</code> subtypes</a>.</p>
+				<p class="note">Refer to the schema.org site for the complete <a
+						href="https://schema.org/CreativeWork#subtypes">list of <code>CreativeWork</code>
+					subtypes</a>.</p>
 			</section>
 
 			<section id="manifest-properties">
@@ -583,26 +615,30 @@ enum ProgressionDirection {
 
 						<p>When a <a href="#manifest-properties">manifest</a> property expects a literal text string as
 							its value &#8212; one that is not language-dependent, such as a code value or date &#8212;
-							its value MUST be expressed as a [[!json]] string.</p>
+							its value MUST be expressed as a [[!json]] <a
+								href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>.</p>
 
 						<p>Literal values are not changed <a href="#manifest-processing">during processing of the
-								manifest</a>, unlike other values which might be, for example, converted to objects.</p>
+								manifest</a>, unlike other values which might be, for example, <a href="#value-objects"
+								>converted to objects</a>.</p>
 					</section>
 
 					<section id="value-number">
 						<h5>Numbers</h5>
 
 						<p>When a <a href="#manifest-properties">manifest</a> property expects a number as its value,
-							the values MUST be expressed as a [[!json]] number.</p>
+							the values MUST be expressed as a [[!json]] <a
+								href="https://tools.ietf.org/html/rfc4627#section-2.4">number</a>.</p>
 					</section>
 
 					<section id="value-objects">
 						<h5>Explicit and Implied Objects</h5>
 
-						<p>Various manifest properties are expected to be expressed as [[!json]]&#160;objects. Although
-							the use of objects is usually recommended, the following sections identify cases where it is
-							also acceptable to use string values that are interpreted as objects depending on the
-							context. The exact mapping of text values to objects is part of the property or object
+						<p>Various manifest properties are expected to be expressed as [[!json]]&#160;<a
+								href="https://tools.ietf.org/html/rfc4627#section-2.2">objects</a>. Although the use of
+							objects is usually recommended, the following sections identify cases where it is also
+							acceptable to use string values that are interpreted as objects depending on the context.
+							The exact mapping of text values to objects is part of the property or object
 							definitions.</p>
 
 						<section id="value-localizable-string">
@@ -612,9 +648,11 @@ enum ProgressionDirection {
 								string as its value, the value MUST be expressed either as:</p>
 
 							<ul>
-								<li>a single string value;</li>
-								<li>an object with a <code>value</code> property containing a the property's text and a
-										<code>language</code> property that identifies the language of the text.</li>
+								<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
+									value; or</li>
+								<li>a [[!json]]&#160;<a href="https://tools.ietf.org/html/rfc4627#section-2.2"
+										>object</a> with a <code>value</code> property containing a the property's text
+									and a <code>language</code> property that identifies the language of the text.</li>
 							</ul>
 
 							<p>A single string value represents an implied object whose <code>value</code> property is
@@ -630,20 +668,21 @@ enum ProgressionDirection {
 								MUST be expressed either as:</p>
 
 							<ul>
-								<li>a single string value;</li>
-								<li>a <a href="#CreatorInfo">CreatorInfo</a> object.</li>
+								<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
+									value; or</li>
+								<li>a <a href="#CreatorInfo"><code>CreatorInfo</code> object</a>.</li>
 							</ul>
 
-							<p>A single string value represents an instance of a CreatorInfo object whose
+							<p>A single string value represents an instance of a <code>CreatorInfo</code> object whose
 									<code>name</code> property is the string's text and whose <code>type</code> is
-								assumed to be <a href="https://schema.org/Person">Person</a> [[!schema.org]].</p>
+								assumed to be <a href="https://schema.org/Person">Person</a>&#160;[[!schema.org]].</p>
 
-							<aside class="example" title="Using a text string instead of a Person object.">
-								<p>The following author name is expressed as a text string:</p>
+							<aside class="example" title="Using a string instead of a Person object.">
+								<p>The following author name is expressed as a string:</p>
 
 								<pre>
 {
-    "author" : "Herman Melville",
+    "author" : "Edgar Allen Poe",
     &#8230;
 }</pre>
 								<p>but, in the context of <a href="#creators">creators</a>, it is equivalent to:</p>
@@ -652,7 +691,7 @@ enum ProgressionDirection {
 {
     "author" : {
         "type" : "Person",
-        "name" : "Herman Melville"
+        "name" : "Edgar Allen Poe"
     },
     &#8230;
 }</pre>
@@ -663,17 +702,18 @@ enum ProgressionDirection {
 						<section id="value-link">
 							<h5>Links</h5>
 
-							<p>When a manifest property links to one or more resources, it MUST be expressed in one of
-								the following two ways:</p>
+							<p>When a manifest property links to one or more resources, it MUST be expressed either
+								as:</p>
 
 							<ol>
-								<li>as a string encoding the <a>URL</a> of the resources; or</li>
-								<li>as an instance of a <a href="#publication-link-def"><code>LinkedResource</code>
+								<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
+									encoding the <a>URL</a> of the resources; or</li>
+								<li>an instance of a <a href="#publication-link-def"><code>LinkedResource</code>
 										object</a> that can be used to express the URL, the media type, and other
 									characteristics of the target resource.</li>
 							</ol>
 
-							<p>A single string value represents an implied <code>LinkedResource</code> object whose
+							<p>A string value represents an implied <code>LinkedResource</code> object whose
 									<code>url</code> property is set to the string value.</p>
 
 							<pre class="example" title="Resource list that includes one link using a relative URL as a string ('datatypes.svg') and two that display the various properties of the a LinkedResource object">
@@ -705,13 +745,13 @@ enum ProgressionDirection {
 
 						<p><dfn data-lt="URL">URLs</dfn> are used to identify resources associated with a <a>digital
 								publication</a>. When a property expects a URL value, it MUST be a <a
-								href="https://url.spec.whatwg.org/#absolute-url-string">valid URL string</a>
-							[[!url]].</p>
+								href="https://url.spec.whatwg.org/#absolute-url-string">valid URL
+							string</a>&#160;[[!url]].</p>
 
 						<p>Manifest URLs are restricted to only the <code>http</code> and <code>https</code>
-							<a href="https://url.spec.whatwg.org/#concept-url-scheme">schemes</a> [[!url]]. URLs MUST
-							dereference to a resource, although user agents are not required to dereference all URLs in
-							the manifest.</p>
+							<a href="https://url.spec.whatwg.org/#concept-url-scheme">schemes</a>&#160;[[!url]]. URLs
+							MUST dereference to a resource, although user agents are not required to dereference all
+							URLs in the manifest.</p>
 
 						<p>In the case of <a href="https://url.spec.whatwg.org/#relative-url-string">relative-URL
 								strings</a>, these are resolved to <a
@@ -723,7 +763,7 @@ enum ProgressionDirection {
 						<ul>
 							<li>In the case of an <a href="#manifest-embed">embedded manifest</a>, it is the <a
 									href="https://www.w3.org/TR/json-ld11/#inheriting-base-iri-from-html-s-base-element"
-									>document base URL of the embedding document</a> [[!json-ld]];</li>
+									>document base URL of the embedding document</a>&#160;[[!json-ld]];</li>
 							<li>In the case of a <a href="#manifest-link">linked manifest</a>, it is the URL of the
 								manifest resource.</li>
 							<li>In the case of a digital publication format that uses <a
@@ -744,8 +784,7 @@ enum ProgressionDirection {
 					<section id="value-id">
 						<h5>Identifiers</h5>
 
-						<p>Identifiers are <a href="https://url.spec.whatwg.org/#concept-url">URL records</a> [[!url]]
-							that can be used to refer to <a class="externalDFN"
+						<p>Identifiers are used to refer to <a class="externalDFN"
 								href="https://www.w3.org/TR/publishing-linking/#dfn-web-content">Web Content</a> in a
 							persistent and unambiguous manner. <abbr title="Uniform Resource Locators">URLs</abbr>,
 								<abbr title="Uniform Resource Names">URNs</abbr>, <abbr
@@ -753,15 +792,19 @@ enum ProgressionDirection {
 								title="International Standard Book Numbers">ISBNs</abbr>, and <abbr
 								title="Persistent Uniform Resource Locators">PURLs</abbr> are all examples of persistent
 							identifiers frequently used in publishing.</p>
+
+						<p>Identifiers MUST be expressed as <a href="https://url.spec.whatwg.org/#concept-url">URL
+								records</a>&#160;[[!url]]</p>
 					</section>
 
 					<section id="value-array">
 						<h5>Arrays</h5>
 
 						<p>When a <a href="#manifest-properties">manifest property</a> allows one or more value of their
-							respective type (<a href="#value-literal">literal</a>, <a href="#value-objects">object</a>,
-							or <a href="#value-url">URL</a>), these values are expressed as [[!json]]&#160;arrays. When
-							a property value is a single element, however, the array syntax MAY be omitted.</p>
+							respective type (e.g., <a href="#value-literal">literal</a>, <a href="#value-objects"
+								>object</a>, or <a href="#value-url">URL</a>), these values are expressed as [[!json]]
+								<a href="https://tools.ietf.org/html/rfc4627#section-2.3">arrays</a>. When a property
+							value is a single element, however, the array syntax MAY be omitted.</p>
 
 						<aside class="example" title="Using a text string instead of an array">
 							<p>As a digital publication typically contains many resources, this declaration of a single
@@ -789,11 +832,10 @@ enum ProgressionDirection {
 					<section id="accessibility">
 						<h5>Accessibility</h5>
 
-						<p>The accessibility properties provides information about the suitability of a <a>digital
-								publication</a> for consumption by users with varying preferred reading modalities.
+						<p>The accessibility properties provide information about the suitability of a <a>digital
+								publication</a> for consumption by users with different preferred reading modalities.
 							These properties typically supplement an evaluation against established accessibility
-							criteria, such as those provided in [[WCAG20]]. (For linking to a detailed accessibility
-							report, see <a href="#accessibility-report"></a>.)</p>
+							criteria, such as those provided in [[wcag21]].</p>
 
 						<p>The following properties are categorized as accessibility properties:</p>
 
@@ -814,7 +856,7 @@ enum ProgressionDirection {
 											<dfn>accessMode</dfn>
 										</code>
 									</td>
-									<td> The human sensory perceptual system or cognitive faculty through which a person
+									<td>The human sensory perceptual system or cognitive faculty through which a person
 										may process or perceive information. </td>
 									<td>One or more text(s).</td>
 									<td>
@@ -830,7 +872,7 @@ enum ProgressionDirection {
 											<dfn>accessModeSufficient</dfn>
 										</code>
 									</td>
-									<td> A list of single or combined accessModes that are sufficient to understand all
+									<td> A list of single or combined access modes that are sufficient to understand all
 										the intellectual content of a resource. </td>
 									<td> One or more <a href="https://schema.org/ItemList">ItemList</a>.</td>
 									<td>
@@ -881,11 +923,8 @@ enum ProgressionDirection {
 											<dfn>accessibilitySummary</dfn>
 										</code>
 									</td>
-									<td>A human-readable summary of specific accessibility features or deficiencies,
-										consistent with the other accessibility metadata but expressing subtleties such
-										as “short descriptions are present but long descriptions will be needed for
-										non-visual users” or “short descriptions are present and no long descriptions
-										are needed.” </td>
+									<td>A human-readable summary of specific accessibility features or deficiencies that
+										is consistent with the other accessibility metadata. </td>
 									<td>Text.</td>
 									<td>
 										<a href="#value-localizable-string">Localizable String</a>
@@ -901,9 +940,9 @@ enum ProgressionDirection {
 						<p class="note">Detailed descriptions of these properties, including the expected values to use
 							with them, are available at [[webschemas-a11y]].</p>
 
-						<p class="note">The author can also provide a reference to a detailed <a
-								href="#accessibility-report">Accessibility Report</a> if more information is needed than
-							can be expressed by these properties.</p>
+						<p class="note">A reference to a detailed <a href="#accessibility-report">accessibility
+								report</a> can also be provided if more information is needed than can be expressed by
+							these properties.</p>
 
 						<pre class="example" title="Example accessiblity metadata for a document with text and images. The publication provides alternative text and long descriptions appropriate for each image, so can also be read in purely textual form.">
 {
@@ -911,6 +950,7 @@ enum ProgressionDirection {
     "type"     : "CreativeWork",
     &#8230;
     "accessMode"            : ["textual", "visual"],
+    "accessibilityFeature"  : ["alternativeText", "longDescription"]
     "accessModeSufficient"  : [
         {
             "type"           : "ItemList",
@@ -930,9 +970,8 @@ enum ProgressionDirection {
 					<section id="address">
 						<h4>Address</h4>
 
-						<p>A <a>digital publication's</a>
-							<dfn>address</dfn> is a <a>URL</a> that identifies its source location. It is expressed
-							using the <code>url</code> property.</p>
+						<p>An <dfn>address</dfn> is a <a>URL</a> that identifies the source location of a <a>digital
+								publication</a>. It is expressed using the <code>url</code> property.</p>
 
 						<table class="zebra">
 							<thead>
@@ -952,7 +991,7 @@ enum ProgressionDirection {
 										</code>
 									</td>
 									<td>URL of the publication.</td>
-									<td>A valid URL string [[!url]].</td>
+									<td>A valid URL string&#160;[[!url]].</td>
 									<td><a href="#value-array">Array</a> of <a href="#value-url">URLs</a></td>
 									<td>
 										<a href="https://schema.org/url"><code>url</code></a> (<a
@@ -972,7 +1011,7 @@ enum ProgressionDirection {
     "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     "type"     : "Book",
     &#8230;
-    "url"      : "https://publisher.example.org/mobydick",
+    "url"      : "https://publisher.example.org/frankenstein",
     &#8230;
 }
 </pre>
@@ -982,8 +1021,8 @@ enum ProgressionDirection {
 						<h5>Canonical Identifier</h5>
 
 						<p>A <a>digital publication's</a>
-							<dfn>canonical identifier</dfn> property provides a unique identifier for the publication.
-							It is expressed using the <code>id</code> property.</p>
+							<dfn>canonical identifier</dfn> property provides a unique identifier for a <a>digital
+								publication</a>. It is expressed using the <code>id</code> property.</p>
 
 						<table class="zebra">
 							<thead>
@@ -1003,7 +1042,7 @@ enum ProgressionDirection {
 										</code>
 									</td>
 									<td>Preferred version of the publication.</td>
-									<td>A URL record [[!url]].</td>
+									<td>A URL record&#160;[[!url]].</td>
 									<td><a href="#value-id">Identifier</a></td>
 									<td>(None)</td>
 								</tr>
@@ -1039,7 +1078,7 @@ enum ProgressionDirection {
     "type"     : "Book",
     &#8230;
     "id"       : "urn:isbn:9780123456789",
-    "url"      : "https://publisher.example.org/mobydick",
+    "url"      : "https://publisher.example.org/wuthering-heights",
     &#8230;
 }
 </pre>
@@ -1048,7 +1087,7 @@ enum ProgressionDirection {
 					<section id="creators">
 						<h5>Creators</h5>
 
-						<p>A <dfn>creator</dfn> is an individual or entity responsible for the creation of the
+						<p>A <dfn>creator</dfn> is an individual or organization responsible for the creation of a
 								<a>digital publication</a>.</p>
 
 						<p>The following properties are categorized as creators:</p>
@@ -1274,19 +1313,20 @@ enum ProgressionDirection {
 							</tbody>
 						</table>
 
-						<p>Creators are represented in one of the following two ways:</p>
+						<p>Creators MUST be represented either as:</p>
 
 						<ol>
-							<li>as a string encoding the name of a <a href="https://schema.org/Person"
-										><code>Person</code></a> [[!schema.org]]; or</li>
-							<li>as an instance of a <a href="https://schema.org/Person"><code>Person</code></a> or <a
-									href="https://schema.org/Organization"><code>Organization</code></a>
-								[[!schema.org]].</li>
+							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
+								encoding the name of a <a href="https://schema.org/Person"
+								><code>Person</code></a>&#160;[[!schema.org]]; or</li>
+							<li>an instance of a <a href="https://schema.org/Person"><code>Person</code></a> or <a
+									href="https://schema.org/Organization"
+								><code>Organization</code></a>&#160;[[!schema.org]].</li>
 						</ol>
 
-						<p>In other words, a single string value is a shorthand for a [[!schema.org]]
-								<code>Person</code> whose <code>name</code> property is set to that string value. (See
-							also <a href="#value-object-entity"></a>.)</p>
+						<p>A single string value is a shorthand for a [[!schema.org]] <code>Person</code> whose
+								<code>name</code> property is set to that string value. (See also <a
+								href="#value-object-entity"></a>.)</p>
 
 						<p>When compiling each set of creator information from a [[!schema.org]] <a
 								href="https://schema.org/Person"><code>Person</code></a> or <a
@@ -1301,10 +1341,10 @@ enum ProgressionDirection {
     "type"     : "Book",
     "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     &#8230;
-    "url"      : "https://publisher.example.org/mobydick",
+    "url"      : "https://publisher.example.org/alice-in-wonderland",
     "author"   : {
         "type"  : "Person",
-        "name"  : "Herman Melville"
+        "name"  : "Lewis Carroll"
     }
 }
 </pre>
@@ -1348,8 +1388,8 @@ enum ProgressionDirection {
 						<h5>Duration</h5>
 
 						<p> The <dfn>global duration</dfn> indicates the overall length of a <em>time-based</em>
-							<a>digital publication</a> (e.g., an audiobook, a book consisting of a series of video
-							clips, etc.). It is expressed as a "Duration" value as defined by&#160;[[!iso8601]]. </p>
+							<a>digital publication</a> (e.g., an audiobook or a book consisting of a series of video
+							clips). It is expressed using the <code>duration</code> property.</p>
 
 						<table class="zebra">
 							<thead>
@@ -1369,7 +1409,7 @@ enum ProgressionDirection {
 										</code>
 									</td>
 									<td>Overall duration of a time-based publication.</td>
-									<td>Duration value as defined by&#160;[[!iso8601]]</td>
+									<td>Duration value as defined by&#160;[[!iso8601]].</td>
 									<td>
 										<a href="#value-literal">Literal</a>
 									</td>
@@ -1400,10 +1440,10 @@ enum ProgressionDirection {
 					<section id="last-modification-date">
 						<h5>Last Modification Date</h5>
 
-						<p>The <dfn>last modification date</dfn> is the date when the <a>digital publication</a> was
-							last updated (i.e., whenever changes were last made to any of the resources of the
-							publication, including the <a>manifest</a>). It is expressed using the
-								<code>dateModified</code> property.</p>
+						<p>The <dfn>last modification date</dfn> is the date when a <a>digital publication</a> was last
+							updated (i.e., whenever changes were last made to any of the resources of the publication,
+							including the <a>manifest</a>). It is expressed using the <code>dateModified</code>
+							property.</p>
 						<table class="zebra">
 							<thead>
 								<tr>
@@ -1425,7 +1465,7 @@ enum ProgressionDirection {
 									<td>A <a href="https://schema.org/Date"><code>Date</code></a> or <a
 											href="https://schema.org/DateTime"><code>DateTime</code></a>
 										value&#160;[[!schema.org]], both expressed in ISO 8601 Date, or Date Time
-										formats, respectively [[iso8601]].</td>
+										formats, respectively&#160;[[!iso8601]].</td>
 									<td>
 										<a href="#value-literal">Literal</a>
 									</td>
@@ -1435,10 +1475,10 @@ enum ProgressionDirection {
 								</tr>
 							</tbody>
 						</table>
-						<p>The last modification date does not necessarily reflect all changes to the publication (e.g.,
-							third-party content could change without the author being aware). User agents SHOULD check
-							the last modification date of individual resources to determine if they have changed and
-							need updating.</p>
+						<p>The last modification date does not necessarily reflect all changes to a publication (e.g.,
+							if a digital publication format allows references to third-party content). User agents
+							SHOULD check the last modification date of individual resources to determine if they have
+							changed and need updating.</p>
 
 						<pre class="example" title="Last modification date of the publication">
 {
@@ -1456,7 +1496,7 @@ enum ProgressionDirection {
 					<section id="publication-date">
 						<h5>Publication Date</h5>
 
-						<p>The <dfn>publication date</dfn> is the date on which the <a>digital publication</a> was
+						<p>The <dfn>publication date</dfn> is the date on which a <a>digital publication</a> was
 							originally published. It represents a static event in the lifecycle of a publication and
 							allows subsequent revisions to be identified and compared. It is expressed using the
 								<code>datePublished</code> property.</p>
@@ -1481,7 +1521,7 @@ enum ProgressionDirection {
 									<td>Creation date of the publication.</td>
 									<td>A <a href="https://schema.org/Date"><code>Date</code></a> or <a
 											href="https://schema.org/DateTime"><code>DateTime</code></a>, both expressed
-										in ISO 8601 Date, or Date Time formats, respectively [[!iso8601]].</td>
+										in ISO 8601 Date, or Date Time formats, respectively&#160;[[!iso8601]].</td>
 									<td>
 										<a href="#value-literal">Literal</a>
 									</td>
@@ -1493,8 +1533,8 @@ enum ProgressionDirection {
 						</table>
 
 						<p>The exact moment of publication is intentionally left open to interpretation: it could be
-							when the publication is first made available online or could be a point in time before
-							publication when the publication is considered final.</p>
+							when the publication is first made available or could be a point in time before publication
+							when the publication is considered final.</p>
 
 						<pre class="example" title="Creation and modification date of the publication">
 {
@@ -1536,7 +1576,8 @@ enum ProgressionDirection {
 										</code>
 									</td>
 									<td>Default <a>language</a> for the publication.</td>
-									<td>One or more language codes as defined in&#160;[[!bcp47]]</td>
+									<td>One or more <a href="https://tools.ietf.org/html/bcp47#section-2.2.9"
+											>well-formed language tags</a>&#160;[[!bcp47]].</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
 									</td>
@@ -1547,7 +1588,8 @@ enum ProgressionDirection {
 							</tbody>
 						</table>
 
-						<p>The natural language MUST be well-formed in terms of &#160;[[!bcp47]].</p>
+						<p>The natural language MUST be a <a href="https://tools.ietf.org/html/bcp47#section-2.2.9"
+								>well-formed language tag</a> &#160;[[!bcp47]].</p>
 
 						<p>If a user agent requires the publication language and it is not available in the manifest, or
 							the obtained value is invalid, the user agent MAY attempt to determine the publication
@@ -1576,8 +1618,10 @@ enum ProgressionDirection {
 					<section id="reading-progression-direction">
 						<h5>Reading Progression Direction</h5>
 
-						<p>The <dfn data-lt="ProgressionDirection">reading progression</dfn> establishes the reading
-							direction from one resource to the next within a <a>digital publication</a>. It is expressed
+						<p>The <dfn data-lt="ProgressionDirection">reading progression direction</dfn> establishes the
+							reading direction from one resource to the next within a <a>digital publication</a>. It is
+							used to adapt such publication-level interactions as menu position, touch gestures, swap
+							direction, and tap zones for next and previous page. The reading progression is expressed
 							using the <code>readingDirection</code> property.</p>
 
 						<table class="zebra">
@@ -1597,8 +1641,8 @@ enum ProgressionDirection {
 											<dfn>readingProgression</dfn>
 										</code>
 									</td>
-									<td>Reading direction from one resource to the other.</td>
-									<td><code>ltr</code> or <code>rtl</code></td>
+									<td>Reading progression direction from one resource to the other.</td>
+									<td>One of: <code>ltr</code> or <code>rtl</code>.</td>
 									<td>
 										<a href="#value-literal">Literal</a>
 									</td>
@@ -1614,24 +1658,19 @@ enum ProgressionDirection {
 							<li><code><dfn>rtl</dfn></code>: right-to-left.</li>
 						</ul>
 
-						<p>The default value is <code>ltr</code>.</p>
+						<p>The default value is <code>ltr</code>. If the <code>readingProgression</code> is not set,
+							user agents MUST use the default value when generating their <a>canonical
+							representation</a>.</p>
 
 						<p>This property has <em>no effect</em> on the rendering of the individual primary resources; it
 							is only relevant for the progression direction from one resource to the other.</p>
-
-						<p class="note">The reading progression of a publication is used to adapt such publication level
-							interactions as menu position, swap direction, defining tap zones to lead the user to the
-							next and previous pages, touch gestures, etc.</p>
-
-						<p>If the <code>readingProgression</code> is not set, user agents MUST use the default value
-								<code>ltr</code> when generating their <a>canonical representation</a>.</p>
 
 						<pre class="example" title="Reading progression set explicitl to ltr">
 {
     "@context"           : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     "type"               : "Book",
     &#8230;
-    "url"                : "https://publisher.example.org/mobydick",
+    "url"                : "https://publisher.example.org/leviathan",
     "readingProgression" : "ltr"
 }
 </pre>
@@ -1640,7 +1679,7 @@ enum ProgressionDirection {
 					<section id="pub-title">
 						<h5>Title</h5>
 
-						<p>The title provides the human-readable name of the <a>digital publication</a>. It is expressed
+						<p>The title provides the human-readable name of a <a>digital publication</a>. It is expressed
 							using the <code>name</code> property.</p>
 
 						<table class="zebra">
@@ -1678,17 +1717,16 @@ enum ProgressionDirection {
 							create one. This specification does not specify what heuristics to use to generate such a
 							title.</p>
 
-						<p class="note">A user agent is not expected to produce a <a
-								data-cite="WCAG20#navigation-mechanisms-title">meaningful title</a>&#160;[[wcag20]] for
-							a publication when one is not specified. </p>
+						<p class="note">A user agent is not expected to produce a <a data-cite="wcag21#page-titled"
+								>meaningful title</a>&#160;[[wcag21]] for a publication when one is not specified. </p>
 
 						<pre class="example" title="Title of the book set explicitly">
 {
     "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     "type"     : "Book",
     &#8230;
-    "url"      : "https://publisher.example.org/mobydick",
-    "name"     : "Moby Dick"
+    "url"      : "https://publisher.example.org/heart-of-darkness",
+    "name"     : "Heart of Darkness"
 }
 </pre>
 					</section>
@@ -1735,18 +1773,10 @@ enum ProgressionDirection {
 											<dfn>readingOrder</dfn>
 										</code>
 									</td>
-									<td></td>
+									<td>Order of progression through the resources of a digital publication.</td>
 									<td>
-										<p>One or more of:</p>
-										<ul>
-											<li>a string, representing the <a>URL</a> of the resource; or</li>
-											<li>an instance of a <a href="#publication-link-def"
-														><code>LinkedResource</code></a> object</li>
-										</ul>
-										<p>The order of items is <em>significant</em>. The URLs MUST NOT include
-											fragment identifiers. Non-HTML resources SHOULD be expressed as
-												<code>LinkedResource</code> objects with their
-												<code>encodingFormat</code> values set.</p>
+										<p>One or more <a href="#publication-link-def"
+											><code>LinkedResource</code></a>.</p>
 									</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-link">Links</a>
@@ -1756,6 +1786,24 @@ enum ProgressionDirection {
 							</tbody>
 						</table>
 
+						<p>Each element of the <code>readingOrder</code> property MUST be expressed either as:</p>
+
+						<ul>
+							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
+								representing the <a>URL</a> of the resource; or</li>
+							<li>an instance of a <a href="#publication-link-def"><code>LinkedResource</code></a>
+								object.</li>
+						</ul>
+
+						<p>A single string value represents an instance of a <code>LinkedResource</code> object whose
+								<code>url</code> property is the string's text.</p>
+
+						<p>The order of items is <em>significant</em>.</p>
+
+						<p>The URLs expressed in the reading order MUST NOT include fragment identifiers. Non-HTML
+							resources SHOULD be expressed as <code>LinkedResource</code> objects with their
+								<code>encodingFormat</code> values set.</p>
+
 						<p>The default reading order MUST include at least one resource.</p>
 
 						<pre class="example" title="Reading order expressed as a simple list of URLs">
@@ -1763,8 +1811,8 @@ enum ProgressionDirection {
     "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     "type"     : "Book",
     &#8230;
-    "url"      : "https://publisher.example.org/mobydick",
-    "name"     : "Moby Dick",
+    "url"      : "https://publisher.example.org/pride-prejudice",
+    "name"     : "Pride and Prejudice",
     "readingOrder" : [
         "html/title.html",
         "html/copyright.html",
@@ -1780,8 +1828,8 @@ enum ProgressionDirection {
     "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     "type"     : "Book",
     &#8230;
-    "url"      : "https://publisher.example.org/mobydick",
-    "name"     : "Moby Dick",
+    "url"      : "https://publisher.example.org/pride-prejudice",
+    "name"     : "Pride and Prejudice",
     "readingOrder" : [{
         "type"           : "LinkedResource",
         "url"            : "html/title.html",
@@ -1802,7 +1850,7 @@ enum ProgressionDirection {
 					<section id="resource-list">
 						<h5>Resource List</h5>
 
-						<p>The <dfn>resource list</dfn> enumerates any additional resources used in the processing and
+						<p>The <dfn>resource list</dfn> enumerates any additional resources used in the processing or
 							rendering of a <a>digital publication</a> that are not already listed in the <a>default
 								reading order</a>. It is expressed using the <code>resources</code> property.</p>
 
@@ -1823,17 +1871,11 @@ enum ProgressionDirection {
 											<dfn>resources</dfn>
 										</code>
 									</td>
-									<td></td>
+									<td>List of additional publication resources used in the processing or rendering of
+										a publication.</td>
 									<td>
-										<p>One or more of:</p>
-										<ul>
-											<li>a string, representing the <a>URL</a> of the resource; or</li>
-											<li>an instance of a <a href="#publication-link-def"
-														><code>LinkedResource</code></a> object</li>
-										</ul>
-										<p>The order of items is <em>not significant</em>. The URLs MUST NOT include
-											fragment identifiers. It is RECOMMENDED to use <code>LinkedResource</code>
-											objects with their <code>encodingFormat</code> values set.</p>
+										<p>One or more <a href="#publication-link-def"
+											><code>LinkedResource</code></a>.</p>
 									</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-link">Links</a>
@@ -1842,6 +1884,24 @@ enum ProgressionDirection {
 								</tr>
 							</tbody>
 						</table>
+
+						<p>Each element of the <code>resources</code> property MUST be expressed either as:</p>
+
+						<ul>
+							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
+								representing the <a>URL</a> of the resource; or</li>
+							<li>an instance of a <a href="#publication-link-def"><code>LinkedResource</code></a>
+								object.</li>
+						</ul>
+
+						<p>A single string value represents an instance of a <code>LinkedResource</code> object whose
+								<code>url</code> property is the string's text.</p>
+
+						<p>The order of items is <em>not significant</em>.</p>
+
+						<p>The URLs MUST NOT include fragment identifiers. It is RECOMMENDED to use
+								<code>LinkedResource</code> objects with their <code>encodingFormat</code> values
+							set.</p>
 
 						<p>The completeness of the resource list can affect the usability of a digital publication in
 							certain reading scenarios (e.g., the ability to read it offline). For this reason, it is
@@ -1887,9 +1947,10 @@ enum ProgressionDirection {
 					<section id="links">
 						<h5>Links</h5>
 
-						<p>The <dfn><code>links</code></dfn> property provides a list of resources that are <em>not</em>
+						<p>The <dfn>Links</dfn> list is used to provide a list of resources that are <em>not</em>
 							required for the processing and rendering of a <a>digital publication</a> (i.e., the content
-							of the publication remains unaffected even if these resources are not available).</p>
+							of the publication remains unaffected even if these resources are not available). Links are
+							expressed using the <code>links</code> property.</p>
 
 						<table class="zebra">
 							<thead>
@@ -1908,17 +1969,11 @@ enum ProgressionDirection {
 											<dfn>links</dfn>
 										</code>
 									</td>
-									<td></td>
+									<td>List of resources associated with a publication but not required for its
+										processing or rendering.</td>
 									<td>
-										<p>One or more of:</p>
-										<ul>
-											<li>a string, representing the <a>URL</a> of the resource; or</li>
-											<li>an instance of a <a href="#publication-link-def"
-														><code>LinkedResource</code></a> object</li>
-										</ul>
-										<p>The order of items is <em>not significant</em>. It is RECOMMENDED to use
-												<code>LinkedResource</code> objects with their
-												<code>encodingFormat</code> and <code>rel</code> values set.</p>
+										<p>One or more <a href="#publication-link-def"
+											><code>LinkedResource</code></a>.</p>
 									</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-link">Links</a>
@@ -1927,6 +1982,23 @@ enum ProgressionDirection {
 								</tr>
 							</tbody>
 						</table>
+
+						<p>Each element of the <code>links</code> property MUST be expressed either as:</p>
+
+						<ul>
+							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
+								representing the <a>URL</a> of the resource; or</li>
+							<li>an instance of a <a href="#publication-link-def"><code>LinkedResource</code></a>
+								object.</li>
+						</ul>
+
+						<p>A single string value represents an instance of a <code>LinkedResource</code> object whose
+								<code>url</code> property is the string's text.</p>
+
+						<p>The order of items is <em>not significant</em>.</p>
+
+						<p>It is RECOMMENDED to use <code>LinkedResource</code> objects with their
+								<code>encodingFormat</code> and <code>rel</code> values set.</p>
 
 						<p>Linked resources are typically made available to user agents to augment or enhance the
 							processing or rendering, such as:</p>
@@ -2006,11 +2078,11 @@ enum ProgressionDirection {
 "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
 "type"       : "Book",
 &#8230;
-"url"        : "https://publisher.example.org/mobydick",
-"name"       : "Moby Dick",
+"url"        : "https://publisher.example.org/time-machine",
+"name"       : "The Time Machine",
 "links"  : [{
 	"type"            : "LinkedResource",
-	"url"             : "https://www.publisher.example.org/mobydick-onix.xml",
+	"url"             : "https://www.publisher.example.org/time-machine/onix.xml",
 	"encodingFormat"  : "application/onix+xml",
 	"rel"             : "describedby"
 },{
@@ -2071,38 +2143,6 @@ enum ProgressionDirection {
 			<section id="manifest-rel">
 				<h3>Resource Relations</h3>
 
-				<section id="rel-intro" class="informative">
-					<h4>Introduction</h4>
-
-					<p>The <a>manifest</a> identifies key resources of a <a>digital publication</a> through the use of
-						link relations. These relations are applied to the <a href="#dom-linkedresource-rel"
-								><code>rel</code> property</a> of <a href="#LinkedResource"><code>LinkedResource</code>
-							objects</a> (e.g., the links found in the <a href="#pub-table-of-contents">table of
-							contents</a> and <a href="#resource-list">resource list</a>).</p>
-
-					<p>The types of resources these relations identify are categorized as follows:</p>
-
-					<dl>
-						<dt>
-							<a href="#informative-rel">informative resources</a>
-						</dt>
-						<dd>
-							<p>Informative resources are resources that contain additional information about the
-								publication, such as its <a href="#privacy-policy">privacy policy</a>, <a
-									href="#accessibility-report">accessibility report</a>, or <a href="#preview"
-									>preview</a>.</p>
-						</dd>
-						<dt>
-							<a href="#structural-rel">structural resources</a>
-						</dt>
-						<dd>
-							<p>Structural resources are key meta structures of the publication, such as the <a
-									href="#cover">cover image</a>, <a href="#table-of-contents">table of contents</a>,
-								and <a href="#page-list">page list</a>.</p>
-						</dd>
-					</dl>
-				</section>
-
 				<section id="informative-rel">
 					<h4>Informative Resources</h4>
 
@@ -2112,7 +2152,7 @@ enum ProgressionDirection {
 						<p>An accessibility report provides information about the suitability of a <a>digital
 								publication</a> for consumption by users with varying preferred reading modalities.
 							These reports typically identify the result of an evaluation against established
-							accessibility criteria, such as those provided in [[WCAG21]], and are an important source of
+							accessibility criteria, such as those provided in [[wcag21]], and are an important source of
 							information in determining the usability of a publication.</p>
 
 						<p>An accessibility report is identified using the <code>accessibility-report</code> link
@@ -2126,19 +2166,19 @@ enum ProgressionDirection {
 							publication.</p>
 
 						<p>It is also RECOMMENDED that the accessibility report be provided in a human-readable format,
-							such as [[!html]]. Augmenting these reports with machine-processable metadata, such as
-							provided in Schema.org [[!schema.org]], is also RECOMMENDED.</p>
+							such as HTML [[!html]]. Augmenting these reports with machine-processable metadata, such as
+							provided in schema.org&#160;[[!schema.org]], is also RECOMMENDED.</p>
 
 						<pre class="example" title="Link to an accessibility report">
 {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     "type"       : "Book",
     &#8230;
-    "url"        : "https://publisher.example.org/mobydick",
-    "name"       : "Moby Dick",
+    "url"        : "https://publisher.example.org/sherlock-holmes",
+    "name"       : "The Adventures of Sherlock Holmes",
     "links"  : [{
         "type"        : "LinkedResource",
-        "url"         : "https://www.publisher.example.org/mobydick-accessibility.html",
+        "url"         : "https://www.publisher.example.org/sherlock-holmes-accessibility.html",
         "rel"         : "accessibility-report"
     },{
         &#8230;
@@ -2164,8 +2204,8 @@ enum ProgressionDirection {
 "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
 "type"       : "Book",
 …
-"url"        : "https://publisher.example.org/mobydick",
-"name"       : "Moby Dick",
+"url"        : "https://publisher.example.org/jekyll-hyde",
+"name"       : "The Strange Case of Dr. Jekyll and Mr. Hyde",
 "links"  : [{
 	"type"            : "LinkedResource",
 	"url"             : "preview.mp3",
@@ -2182,11 +2222,11 @@ enum ProgressionDirection {
 "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
 "type"       : "Book",
 …
-"url"        : "https://publisher.example.org/mobydick",
-"name"       : "Moby Dick",
+"url"        : "https://publisher.example.org/jekyll-hyde",
+"name"       : "The Strange Case of Dr. Jekyll and Mr. Hyde",
 "links"  : [{
 	"type"            : "LinkedResource",
-	"url"             : "https://publisher.example.org/mobydickpreview.html",
+	"url"             : "https://publisher.example.org/jekyll-hyde-preview.html",
 	"encodingFormat"  : "text/html",
 	"rel"             : "preview"
 },{
@@ -2266,8 +2306,8 @@ enum ProgressionDirection {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     "type"       : "Book",
     &#8230;
-    "url"        : "https://publisher.example.org/donquixote",
-    "name"       : "Don Quixote",
+    "url"        : "https://publisher.example.org/adam-bede",
+    "name"       : "Adam Bede",
     "resources"  : [{
         "type"           : "LinkedResource",
         "url"            : "cover.html",
@@ -2306,7 +2346,7 @@ enum ProgressionDirection {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     "type"       : "Book",
     &#8230;
-    "url"        : "https://publisher.example.org/donquixote",
+    "url"        : "https://publisher.example.org/gullivers-travels",
     "name"       : "Gulliver's Travels",
     "resources"  : [{
         "type"           : "LinkedResource",
@@ -2333,23 +2373,21 @@ enum ProgressionDirection {
 							within a <a>digital publication</a>.</p>
 
 						<p>The page list is identified by the <code>pagelist</code> link relation. The <a
-								href="#value-url">URL</a> expressed in the <code>url</code> term MUST NOT include a
-							fragment identifier.</p>
+								href="#value-url">URL</a> expressed in the <code>url</code> term of the resource that
+							identifies the page list MUST NOT include a fragment identifier.</p>
 
 						<p class="ednote">The <code>pagelist</code> term is not currently registered in the IANA link
 							relations but the Working Group expects to add it.</p>
 
-						<p>The link to the page list MAY be specified in either the <a href="#default-reading-order"
-								>default reading order</a> or <a href="#resource-list">resource-list</a>, but MUST NOT
-							be specified in both.</p>
+						<p>The link to the page list MUST NOT be specified in the <a href="#links">links list</a>.</p>
 
 						<pre class="example" title="Page list identified in another resource of the publication">
 {
 "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
 "type"       : "Book",
 &#8230;
-"url"        : "https://publisher.example.org/mobydick",
-"name"       : "Moby Dick",
+"url"        : "https://publisher.example.org/metamorphosis",
+"name"       : "Metamorphosis",
 "resources"  : [{
 	"type"       : "LinkedResource",
 	"url"        : "toc_file.html",
@@ -2370,11 +2408,11 @@ enum ProgressionDirection {
 
 						<p>The <dfn data-lt="toc">table of contents</dfn> is identified by the <code>contents</code>
 							link relation&#160;[[!iana-link-relations]]. The <a href="#value-url">URL</a> expressed in
-							the <code>url</code> term MUST NOT include a fragment identifier.</p>
+							the <code>url</code> term of the resource that identifies the table of contents MUST NOT
+							include a fragment identifier.</p>
 
-						<p>The link to the table of contents MAY be specified in either the <a
-								href="#default-reading-order">default reading order</a> or <a href="#resource-list"
-								>resource-list</a>, but MUST NOT be specified in both.</p>
+						<p>The link to the table of contents MUST NOT be specified in the <a
+								href="#default-reading-order">links list</a>.</p>
 
 						<p>The RECOMMENDED structure and processing model for the table of contents is defined in <a
 								href="#app-toc-structure"></a>.</p>
@@ -2384,8 +2422,8 @@ enum ProgressionDirection {
     "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     "type"       : "Book",
     &#8230;
-    "url"        : "https://publisher.example.org/mobydick",
-    "name"       : "Moby Dick",
+    "url"        : "https://publisher.example.org/ilprincipe",
+    "name"       : "Il Principe",
     "resources"  : [{
         "type"       : "LinkedResource",
         "url"        : "toc_file.html",
@@ -2409,7 +2447,7 @@ enum ProgressionDirection {
 					<ul>
 						<li>through the use of relations defined in [[!iana-relations]]; or</li>
 						<li>through the use of <a href="https://tools.ietf.org/html/rfc8288#section-2.1.2">extension
-								relation types</a> [[!rfc8288]].</li>
+								relation types</a>&#160;[[!rfc8288]].</li>
 					</ul>
 
 					<p>Use of relations from [[!iana-relations]] is RECOMMENDED.</p>
@@ -2463,7 +2501,7 @@ enum ProgressionDirection {
 						href="https://www.w3.org/TR/html5/semantics-scripting.html#the-script-element"
 							><code>script</code> element</a>&#160;[[!html]] whose <a
 						href="https://www.w3.org/TR/json-ld11/#embedding-json-ld-in-html-documents"><code>type</code>
-						attribute is set to <code>application/ld+json</code></a> [[!json-ld]].</p>
+						attribute is set to <code>application/ld+json</code></a>&#160;[[!json-ld]].</p>
 
 				<pre class="example" title="A publication manifest included in an HTML document">
 &lt;script type="application/ld+json"&gt;
@@ -2501,7 +2539,7 @@ enum ProgressionDirection {
 				<p> In order for a <a>digital publication</a> format to be compatible with this specification, following
 					conditions MUST be met: </p>
 
-				<ul>
+				<ol>
 					<li>It MUST adhere to the manifest format requirements defined in this specification.</li>
 					<li>The generic processing steps described in <a href="#manifest-processing"></a> MUST remain valid
 						for the extended manifest. To achieve this, and if new terms are added to the general manifest,
@@ -2510,17 +2548,13 @@ enum ProgressionDirection {
 								categories used in the algorithm (e.g., <a href="#value-array">array</a> or <a
 									href="#value-localizable-string">localizable string</a>). This means the relevant
 								canonicalization steps will be automatically executed for those terms </li>
-							<li>If necessary, the profile MAY define its own canonicalization step, to be executed as
-								the <a href="#canonicalization-extension-point">last step of the general
-									canonicalization algorithm</a>. Such an extra step MUST NOT invalidate the results
-								of any of the steps defined for the <a href="#manifest-processing">processing
-									algorithm</a> in general. </li>
+							<li>If necessary, the profile MAY define its own canonicalization step(s), to be executed at
+								the designated extension points within the <a href="#manifest-processing">processing
+									algorithm</a>. Such extra steps MUST NOT invalidate the results of any of the steps
+								defined for the <a href="#manifest-processing">processing algorithm</a> in general.</li>
 						</ul>
 					</li>
-					<li>If necessary, the profile MAY define its own manifest processing step, to be executed as part of
-						the steps described in <a href="#manifest-processing"></a>
-					</li>
-				</ul>
+				</ol>
 				<p class="ednote"> Adding an example of a term added by, e.g., the audiobook profile would be a good
 					idea, when available. </p>
 			</section>
@@ -2537,9 +2571,9 @@ enum ProgressionDirection {
 			<ul>
 				<li><var>text</var>: a UTF-8 string containing the manifest;</li>
 				<li><var>base</var>: a URL string that represents the base URL for the manifest.</li>
-				<li><var>document</var>: the <a data-cite="html#the-document-object">HTML Document (DOM) Node</a>
-					[[html]] of the document that <a href="#manifest-discovery">references the manifest</a>, when
-					available.</li>
+				<li><var>document</var>: the <a data-cite="html#the-document-object">HTML Document (DOM)
+					Node</a>&#160;[[!html]] of the document that <a href="#manifest-discovery">references the
+						manifest</a>, when available.</li>
 			</ul>
 
 			<p class="note">This algorithm does not define how the manifest is discovered and obtained. The steps by
@@ -2550,29 +2584,29 @@ enum ProgressionDirection {
 				whatever language and form is appropriate.</p>
 
 			<ol>
-				<li>
+				<li id="processing-init">
 					<p>Let <var>processed</var> be an object containing the <a>canonical representation</a> of the
 						manifest.</p>
 				</li>
 
-				<li>
+				<li id="processing-json">
 					<p>Let <var>manifest</var> be the result of <a data-cite="ecmascript#sec-json.parse">parsing</a>
-						<var>text</var> as JSON [[!ecmascript]]. If parsing throws an error, terminate this
+						<var>text</var> as JSON&#160;[[!ecmascript]]. If parsing throws an error, terminate this
 						algorithm.</p>
 				</li>
 
-				<li>
-					<p>If typeof(<var>manifest</var>) is not <code>Object</code> [[!ecmascript]], terminate this
+				<li id="processing-object">
+					<p>If typeof(<var>manifest</var>) is not <code>Object</code>&#160;[[!ecmascript]], terminate this
 						algorithm.</p>
 				</li>
 
-				<li>
+				<li id="processing-context">
 					<p>(<a href="#manifest-context"></a>) If <var>manifest["@context"]</var> does not contain the values
 							"<code>https://schema.org</code>" and "<code>https://www.w3.org/ns/pub-context</code>" (in
 						this order), issue an error and terminate this algorithm.</p>
 				</li>
 
-				<li>
+				<li id="processing-expansion">
 					<p>Iterate over each property <var>term</var> in <var>manifest</var> and expand its value, as
 						necessary, as follows. More than one step MAY apply.</p>
 					<p class="note"> The steps below depend on the expected value category of a <var>term</var>. Care
@@ -2583,48 +2617,32 @@ enum ProgressionDirection {
 					<p>For this step, the variable <var>current</var> is set to the value of <var>manifest[term]</var>
 						and is updated by each applicable transformation.</p>
 					<ol style="list-style-type: lower-alpha;">
-						<li>
+						<li id="processing-expansion-arrays">
 							<p>(<a href="#value-array"></a>) If <var>term</var> expects an <a href="#value-array"
 									>array</a> but <var>current</var> contains a string or object <var>value</var>,
 								convert <var>current</var> to an array and push <var>value</var> onto it.</p>
 							<details>
 								<summary>Explanation</summary>
-								<p>A number of terms require their values to be arrays but, for the sake of convenience,
-									authors are allowed to use a single value instead of a one element array. For
-									example,</p>
+								<p>A number of terms require their values to be arrays, but, for the sake of
+									convenience, authors are allowed to use a single value instead of a one element
+									array. For example,</p>
 								<pre class="example">{
     "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "name"      : "Moby Dick",
-    "author"    : "Herman Melville",
-    "resources" : [{
-        "type"           : "LinkedResource",
-        "rel"            : "cover",
-        "url"            : "images/cover.jpg",
-        "encodingFormat" : "image/jpeg"
-    },
-        &#8230;
-    }],
+    "name"      : "Et dukkehjem",
+    "author"    : "Henrik Ibsen",
     &#8230;
 }</pre>
 								<p>yields:</p>
 								<pre class="example">{
     "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "name"      : ["Moby Dick"],
-    "author"    : ["Herman Melville"],
-    "resources" : [{
-        "type"           : ["LinkedResource"],
-        "rel"            : ["cover"],
-        "url"            : "images/cover.jpg",
-        "encodingFormat" : "image/jpeg"
-    },
-        &#8230;
-    }],
+    "name"      : ["Et dukkehjem"],
+    "author"    : ["Henrik Ibsen"],
     &#8230;
 }</pre>
 							</details>
 						</li>
 
-						<li>
+						<li id="processing-expansion-entities">
 							<p>(<a href="#value-object-entity"></a>) If <var>term</var> expects an <a
 									href="#value-object-entity">entity</a> but the value of <var>current</var> is a
 								string <var>str</var>, convert <var>current</var> to an object with the following
@@ -2634,16 +2652,16 @@ enum ProgressionDirection {
 									"<code>Person</code>";</p></li>
 								<li><p><var>name</var> &#8211; set to <var>str</var>.</p></li>
 							</ul>
-							<p>If typeof(<var>current</var>) is <code>Array</code> [[!ecmascript]], perform this step on
-								each value of the array.</p>
+							<p>If typeof(<var>current</var>) is <code>Array</code>&#160;[[!ecmascript]], perform this
+								step on each element of the array.</p>
 							<details>
 								<summary>Explanation</summary>
 								<p>Authors, editors, etc., are expected to be explicitly designed as an object of type
-										<code>Person</code> but, for the sake of convenience, only their name has to be
+										<code>Person</code>, but, for the sake of convenience, only their name has to be
 									specified. For example:</p>
 								<pre class="example">{
     "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "author"    : ["Herman Melville"],
+    "author"    : ["Ralph Ellison"],
     &#8230;
 }</pre>
 								<p>This rule converts the string values to objects, yielding the following for the
@@ -2652,7 +2670,7 @@ enum ProgressionDirection {
     "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     "author"    : [{
         "type" : ["Person"],
-        "name" : "Herman Melville"
+        "name" : "Ralph Ellison"
     }],
     &#8230;
 }</pre>
@@ -2661,7 +2679,7 @@ enum ProgressionDirection {
 							</details>
 						</li>
 
-						<li id="step-localizable-string">
+						<li id="processing-expansion-localizable-strings">
 							<p>(<a href="#value-localizable-string"></a>) If <var>term</var> expects a <a
 									href="#value-localizable-string">localizable string</a> and <var>current</var>
 								contains a string <var>str</var>, convert <var>current</var> to an object with the
@@ -2677,51 +2695,57 @@ enum ProgressionDirection {
 										omitted.</p>
 								</li>
 							</ul>
-							<p>If typeof(<var>current</var>) is <code>Array</code> [[!ecmascript]], perform this step on
-								each value of the array.</p>
-							<p>If typeof(<var>current</var>) is <code>Object</code> [[!ecmascript]], perform this step
-								on each property of the object.</p>
+							<p>If typeof(<var>current</var>) is <code>Array</code>&#160;[[!ecmascript]], perform this
+								step on each element of the array.</p>
+							<p>If typeof(<var>current</var>) is <code>Object</code>&#160;[[!ecmascript]], perform this
+								step on each property of the object.</p>
 							<details>
 								<summary>Explanation</summary>
 								<p>Natural language text values are expected to be explicitly designed as localizable
-									string objects but, for the sake of convenience, can be simple strings For example,
-									if no language information has been provided via <code>inLanguage</code> in the
-									manifest then:</p>
+									string objects, but, for the sake of convenience, can be simple strings. For
+									example, if no language information has been provided via the <a
+										href="#manifest-lang-dir-global">global language declaration</a> then:</p>
 								<pre class="example">{
     "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "name"      : ["Moby Dick"],
+    "name"      : ["La Comédie humaine"],
     &#8230;
 }</pre>
 								<p>yields:</p>
 								<pre class="example">{
     "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     "name"      : [{
-        "value" : "Moby Dick"
+        "value" : "La Comédie humaine"
     }],
     &#8230;
 }</pre>
-								<p>If an explicit language has also been provided in the manifest, that language is also
+								<p>If, however, an explicit language has been provided in the manifest, that language is
 									added to the localizable string object. For example,</p>
 								<pre class="example">{
-    "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "inLanguage" : "en",
-    "name"       : ["Moby Dick"],
+    "@context"  : [
+                     "https://schema.org",
+                     "https://www.w3.org/ns/pub-context",
+                     {"language": "fr"}
+                  ],
+    "name"       : ["La Comédie humaine"],
     &#8230;
 }</pre>
 								<p>yields:</p>
 								<pre class="example">{
-    "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "inLanguage": "en",
+    "@context"  : [
+                     "https://schema.org",
+                     "https://www.w3.org/ns/pub-context",
+                     {"language": "fr"}
+                  ],
     "name"      : [{
-        "value"    : "Moby Dick",
-        "language" : "en"
+        "value"    : "La Comédie humaine",
+        "language" : "fr"
     }],
     &#8230;
 }</pre>
 							</details>
 						</li>
 
-						<li>
+						<li id="processing-expansion-links">
 							<p>(<a href="#value-link"></a>) If <var>term</var> is a <a
 									href="#resource-categorization-properties">resource categorization property</a> and
 								any value in the array in <var>current</var> is a string, convert each string
@@ -2734,13 +2758,13 @@ enum ProgressionDirection {
 							<details>
 								<summary>Explanation</summary>
 								<p>Resource links are expected to be explicitly designed as an object of type
-										<code>LinkedResource</code> but, for the sake of convenience, only their
+										<code>LinkedResource</code>, but, for the sake of convenience, only their
 									absolute or relative URL has to be specified. For example,</p>
 								<pre class="example">{
     "@context"  : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     &#8230;
     "resources" : [
-        "css/mobydick.css",
+        "css/book.css",
         &#8230;
     ],
     &#8230;
@@ -2752,7 +2776,7 @@ enum ProgressionDirection {
     &#8230;
     "resources" : [{
         "type" : ["LinkedResource"],
-        "url"  : "css/mobydick.css"
+        "url"  : "css/book.css"
     },
         &#8230;
     ],
@@ -2763,15 +2787,15 @@ enum ProgressionDirection {
 							</details>
 						</li>
 
-						<li>
+						<li id="processing-expansion-urls">
 							<p>(<a href="#value-url"></a>) If <var>term</var> expects a <a href="#value-url">URL</a> and
 								the value of <var>current</var> is a string that is not an <a
 									data-cite="!url/#absolute-url-string">absolute URL string</a>, resolve the value
-								using the value of <var>base</var> [[!rfc1808]].</p>
-							<p>If typeof(<var>current</var>) is <code>Array</code> [[!ecmascript]], perform this step on
-								each value of the array.</p>
-							<p>If typeof(<var>current</var>) is <code>Object</code> [[!ecmascript]], perform this step
-								on each property of the object.</p>
+								using the value of <var>base</var>&#160;[[!rfc1808]].</p>
+							<p>If typeof(<var>current</var>) is <code>Array</code>&#160;[[!ecmascript]], perform this
+								step on each element of the array.</p>
+							<p>If typeof(<var>current</var>) is <code>Object</code>&#160;[[!ecmascript]], perform this
+								step on each property of the object.</p>
 							<details>
 								<summary>Explanation</summary>
 								<p>All relative URLs in the publication manifest must be resolved against the base value
@@ -2779,7 +2803,7 @@ enum ProgressionDirection {
 							</details>
 						</li>
 
-						<li id="canonicalization-extension-point">
+						<li id="processing-expansion-extension">
 							<p>(<a href="#mod-compat"></a>, extension point) if a <a>profile</a> defines processing
 								steps for profile-specific terms, those steps are executed at this point.</p>
 						</li>
@@ -2787,26 +2811,33 @@ enum ProgressionDirection {
 					<p>Set <var>processed[term]</var> to the value of <var>current</var>.</p>
 				</li>
 
-				<li>
+				<li id="processing-defaults">
 					<p>Add defaults from <var>document</var> for the following properties, when applicable:</p>
 					<ol style="list-style-type: lower-alpha;">
-						<li>
+						<li id="processing-defaults-title">
 							<p>(<a href="#pub-title"></a>) If <var>processed["name"]</var> is not set, or its value is
 								an empty string:</p>
 							<ul>
-								<li>Create a new <var>object</var>: <ul>
-										<li> if the <a data-cite="html#the-title-element"><code>title</code></a> element
-											[[html]] of <var>document</var> is set and its contains is not empty, set
-												<var>object["value"]</var> to the text content of the <code>title</code>
-											element and, if applicable, set <var>object["language"]</var> to the <a
-												data-cite="html#the-lang-and-xml:lang-attributes"
-											>language</a>&#160;[[html]]. </li>
-										<li> otherwise, generate a value for <var>object["value"]</var> (see the <a
-												href="#generate_title">separate note for details</a>) and issue a
-											warning. </li>
+								<li>
+									<p>Create a new object <var>title</var>:</p>
+									<ul>
+										<li>
+											<p>if the <a data-cite="html#the-title-element"><code>title</code></a>
+												element&#160;[[!html]] of <var>document</var> is set and its contains is
+												not empty, set <var>title["value"]</var> to the text content of the
+													<code>title</code> element and, if applicable, set
+													<var>title["language"]</var> to the <a
+													data-cite="html#the-lang-and-xml:lang-attributes"
+												>language</a>&#160;[[!html]].</p>
+										</li>
+										<li>
+											<p>otherwise, generate a value for <var>title["value"]</var> (see the <a
+													href="#generate_title">separate note for details</a>) and issue a
+												warning.</p>
+										</li>
 									</ul>
 								</li>
-								<li>Set <var>processed["name"]</var> to an empty array and push <var>object</var> onto
+								<li>Set <var>processed["name"]</var> to an empty array and add <var>title</var> to
 									it.</li>
 							</ul>
 							<details>
@@ -2816,7 +2847,7 @@ enum ProgressionDirection {
 									example:</p>
 								<pre class="example">&lt;html&gt;
 &lt;head lang="en"&gt;
-    &lt;title&gt;Moby Dick&lt;/title&gt;
+    &lt;title&gt;The Golden Bough&lt;/title&gt;
     &#8230;
     &lt;script type="application/ld+json"&gt;
     {
@@ -2828,7 +2859,7 @@ enum ProgressionDirection {
 								<pre class="example">{
     "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
     "name"     : [{
-        "value" : "Moby Dick",
+        "value" : "The Golden Bough",
         "language" : "en"
     }],
     &#8230;
@@ -2836,16 +2867,20 @@ enum ProgressionDirection {
 							</details>
 						</li>
 
-						<li id="reading-order">
+						<li id="processing-defaults-reading-order">
 							<p>(<a href="#default-reading-order"></a>) If <var>processed["readingOrder"]</var> is not
-								set or its value is an empty string or array, create an object:</p>
+								set or its value is an empty string or array:</p>
 							<ul>
-								<li>if <a data-cite="!dom#concept-document-url">document.URL</a> is not set, issue an
-									error and terminate this algorithm.</li>
-								<li>otherwise, create an object and set its <var>url</var> property to the value of <a
-										data-cite="!dom#concept-document-url">document.URL</a>. Set
-										<var>processed["readingOrder"]</var> to an empty array and push the object onto
-									it. </li>
+								<li>
+									<p>if <a data-cite="!dom#concept-document-url">document.URL</a> is not set, issue an
+										error and terminate this algorithm.</p>
+								</li>
+								<li>
+									<p>otherwise, create an object and set its <var>url</var> property to the value of
+											<a data-cite="!dom#concept-document-url">document.URL</a>. Set
+											<var>processed["readingOrder"]</var> to an empty array and add the object to
+										it.</p>
+								</li>
 							</ul>
 							<details>
 								<summary>Explanation</summary>
@@ -2855,17 +2890,17 @@ enum ProgressionDirection {
 							</details>
 						</li>
 
-						<li id="html-extension-point">
+						<li id="processing-defaults-extension">
 							<p>If a <a>profile</a> specifies <var>document</var> fallbacks, those steps are executed at
 								this point.</p>
 						</li>
 					</ol>
 				</li>
 
-				<li>
+				<li id="processing-checks">
 					<p>Perform data integrity checks on the following properties in <var>processed</var>:</p>
 					<ol style="list-style-type: lower-alpha;">
-						<li>
+						<li id="processing-checks-entities">
 							<p>For each property <var>term</var> in <var>processed</var> that expects an array of <a
 									href="#value-object-entity">entities</a>, check whether each value <var>entry</var>
 								in <var>processed[term]</var> has its <var>name</var> property set. If not, remove
@@ -2874,59 +2909,61 @@ enum ProgressionDirection {
 								object in which one or more properties expect entities.</p>
 						</li>
 
-						<li>
+						<li id="processing-checks-language">
 							<p>(<a href="#manifest-lang-dir-global"></a> and <a href="#manifest-lang-dir-local"></a>)
-								Recursively check that every <var>language</var> property in <var>processed</var> is
-								well-formed [[!bcp47]] and issue a warning for any invalid values found.</p>
+								Recursively check that every <var>language</var> property in <var>processed</var> is <a
+									href="https://tools.ietf.org/html/bcp47#section-2.2.9">valid</a>&#160;[[!bcp47]] and
+								issue a warning for any invalid values found.</p>
 						</li>
 
-						<li>
+						<li id="processing-checks-direction">
 							<p>(<a href="#manifest-lang-dir-global"></a>) If <var>processed["direction"]</var> is set
 								and its value is not one of the <a href="#manifest-lang-dir-global">required directional
 									values</a>, issue a warning.</p>
 						</li>
 
-						<li>
+						<li id="processing-checks-type">
 							<p>(<a href="#publication-types"></a>) If <var>processed["type"]</var> is not set or
 								contains an empty value, set its value to an array with the value
 									"<code>CreativeWork</code>" and issue a warning.</p>
 						</li>
 
-						<li>
+						<li id="processing-checks-duration">
 							<p>(<a href="#duration"></a>) If <var>processed["duration"]</var> is set and its value is
 								not a valid duration value, per&#160;[[!iso8601]], issue a warning.</p>
 						</li>
 
-						<li>
+						<li id="processing-checks-last-mod">
 							<p>(<a href="#last-modification-date"></a>) If <var>processed["dateModified"]</var> is set
 								and its value is not a valid date or date-time per&#160;[[!iso8601]], issue a
 								warning.</p>
 						</li>
 
-						<li>
+						<li id="processing-checks-pub-date">
 							<p>(<a href="#publication-date"></a>) If <var>processed["datePublished"]</var> is set and
 								its value is not a valid date or date-time per&#160;[[!iso8601]], issue a warning.</p>
 						</li>
 
-						<li>
+						<li id="processing-checks-inlanguage">
 							<p>(<a href="#language-and-dir"></a>) If <var>processed["inLanguage"]</var> is set, check
-								that each value in its array is well-formed [[!bcp47]] and issue a warning for any
-								invalid values found.</p>
+								that each value in its array is <a
+									href="https://tools.ietf.org/html/bcp47#section-2.2.9">valid</a>&#160;[[!bcp47]] and
+								issue a warning for any invalid values found.</p>
 						</li>
-						
-						<li>
-							<p>(<a href="#reading-progression-direction"></a>) Verify <var>processed["readingProgression"]</var> as
-								follows:</p>
+
+						<li id="processing-checks-progression-dir">
+							<p>(<a href="#reading-progression-direction"></a>) Verify
+									<var>processed["readingProgression"]</var> as follows:</p>
 							<ul>
 								<li>If the property is not set, set its value to "<code>ltr</code>".</li>
 								<li>Otherwise, if the property is set but is not one of the <a
-									href="#reading-progression-direction">required directional values</a>, issue a
+										href="#reading-progression-direction">required directional values</a>, issue a
 									warning.</li>
 								<li>Otherwise, do nothing.</li>
 							</ul>
 						</li>
-						
-						<li>
+
+						<li id="processing-checks-urls">
 							<p>(<a href="#resource-categorization-properties"></a>) For each <a
 									href="#resource-categorization-properties">resource categorization property</a>
 								<var>term</var> in <var>processed</var>, check whether each object <var>P</var> in
@@ -2943,19 +2980,21 @@ enum ProgressionDirection {
 							</ul>
 						</li>
 
-						<li>
+						<li id="processing-checks-length">
 							<p>(<a href="#LinkedResource"></a>) For each property <var>term</var> in
 									<var>processed</var> that expects type <a>LinkedResource</a>, issue a warning if
 									<var>term["length"]</var> is set and is not a valid number.</p>
 						</li>
 
-						<li>If a <a>profile</a> specifies data validation checks, those steps are executed at this
-							point.</li>
+						<li id="processing-checks-extension">
+							<p>If a <a>profile</a> specifies data validation checks, those steps are executed at this
+								point.</p>
+						</li>
 					</ol>
 				</li>
 			</ol>
 
-			<p class="note"> How error and warning messages are reported is user agent dependent.</p>
+			<p class="note">How error and warning messages are reported is user agent dependent.</p>
 		</section>
 		<section id="app-custom-types" class="appendix">
 			<h2>Custom Type Definition</h2>
@@ -3084,10 +3123,10 @@ enum ProgressionDirection {
 							<td>A cryptographic hashing of the resource that allows its integrity to be verified.
 								OPTIONAL.</td>
 							<td><p>One or more whitespace-separated sets of <a
-										href="https://www.w3.org/TR/SRI/#dfn-integrity-metadata">integrity metadata</a>
-									[[!sri]]. The value MUST conform to the <a
+										href="https://www.w3.org/TR/SRI/#dfn-integrity-metadata">integrity
+									metadata</a>&#160;[[!sri]]. The value MUST conform to the <a
 										href="https://www.w3.org/TR/SRI/#the-integrity-attribute">metadata
-										definition</a> [[!sri]].</p>
+										definition</a>&#160;[[!sri]].</p>
 								<p>Refer to [[!sri]] for the <a
 										href="https://www.w3.org/TR/SRI/#cryptographic-hash-functions">list of
 										cryptographic hashing functions</a> that user agents are expected to
@@ -3106,7 +3145,7 @@ enum ProgressionDirection {
 							</td>
 							<td>The total length of a time-based media resource in (possibly fractional) seconds.
 								OPTIONAL</td>
-							<td> Number </td>
+							<td>Number</td>
 							<td>
 								<a href="#value-number">Number</a>
 							</td>
@@ -3198,7 +3237,7 @@ dictionary LinkedResource {
 								</code>
 							</td>
 							<td>A canonical identifier associated with the creator. OPTIONAL.</td>
-							<td>A URL record [[!url]].</td>
+							<td>A URL record&#160;[[!url]].</td>
 							<td>
 								<a href="#value-id">Identifier</a>
 							</td>
@@ -3295,7 +3334,7 @@ dictionary CreatorInfo {
 							</td>
 							<td>The value of the localizable string. REQUIRED.</td>
 							<td>Text.</td>
-							<td></td>
+							<td><a href="#value-literal">Literal</a></td>
 							<td>(None)</td>
 						</tr>
 						<tr>
@@ -3305,7 +3344,8 @@ dictionary CreatorInfo {
 								</code>
 							</td>
 							<td>The language of the value. OPTIONAL.</td>
-							<td>A language code as defined in [[!bcp47]].</td>
+							<td>A <a href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
+								tag</a>&#160;[[!bcp47]].</td>
 							<td><a href="#value-literal">Literal</a></td>
 							<td>(None)</td>
 						</tr>
@@ -3328,12 +3368,13 @@ dictionary LocalizableString {
 				<h3>Introduction</h3>
 
 				<p>To facilitate navigation within pages and across sites, HTML uses the <a
-						href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code> element</a>
-					[[html]] to express lists of links. Although generic in nature by default, the purpose of a
-						<code>nav</code> element can be more specifically identified by use of the <a
-						href="https://www.w3.org/TR/html/dom.html#aria-role-attribute"><code>role</code> attribute</a>
-					[[html]]. In particular, the <code>doc-toc</code> role from the [[dpub-aria-1.0]] vocabulary
-					identifies the <code>nav</code> element as the <a>digital publication's</a> table of contents.</p>
+						href="https://www.w3.org/TR/html/sections.html#the-nav-element"><code>nav</code>
+					element</a>&#160;[[html]] to express lists of links. Although generic in nature by default, the
+					purpose of a <code>nav</code> element can be more specifically identified by use of the <a
+						href="https://www.w3.org/TR/html/dom.html#aria-role-attribute"><code>role</code>
+					attribute</a>&#160;[[html]]. In particular, the <code>doc-toc</code> role from the [[dpub-aria-1.0]]
+					vocabulary identifies the <code>nav</code> element as the <a>digital publication's</a> table of
+					contents.</p>
 
 				<p>Including an identifiable table of contents is an accessible way to produce any <a>digital
 						publication</a>, but due to the flexibility of HTML markup, it also presents challenges for user
@@ -3374,7 +3415,7 @@ dictionary LocalizableString {
 					<dd>
 						<p>Although a title for the table of contents is optional, to avoid having a user agent generate
 							a placeholder title when one is needed, it is advised to add one. Titles are specified using
-							any of the [[html]] <a
+							any of the [[!html]]&#160;<a
 								href="https://www.w3.org/TR/html/sections.html#the-h1-h2-h3-h4-h5-and-h6-elements"
 									><code>h1</code> through <code>h6</code> elements</a>. Note that only the first such
 							element is recognized as the title. If a heading element is not found before the <a
@@ -3383,8 +3424,9 @@ dictionary LocalizableString {
 					</dd>
 					<dt id="toc-list-links">List of Links</dt>
 					<dd>
-						<p>The first [[html]] <a href="https://www.w3.org/TR/html/grouping-content.html#the-ol-element"
-									><code>ol</code></a> or <a
+						<p>The first [[!html]]&#160;<a
+								href="https://www.w3.org/TR/html/grouping-content.html#the-ol-element"
+								><code>ol</code></a> or <a
 								href="https://www.w3.org/TR/html/grouping-content.html#the-ul-element"
 								><code>ul</code></a> list element encountered in the <code>nav</code> element is assumed
 							to contain the list that defines the links into the content. This list will be found even if
@@ -3423,7 +3465,7 @@ dictionary LocalizableString {
 					<dt id="toc-skipped-elements">Skipped Elements</dt>
 					<dd>
 						<p>A small set of elements are ignored when the parsing table of contents to avoid
-							misinterpretation. These are the [[html]] <a
+							misinterpretation. These are the [[!html]]&#160;<a
 								href="https://www.w3.org/TR/html/dom.html#sectioning-content">sectioning content
 								elements</a> and <a href="https://www.w3.org/TR/html/sections.html#sectioning-roots"
 								>sectioning root elements</a>. The reason they are ignored is because they can defined
@@ -3549,8 +3591,9 @@ dictionary LocalizableString {
 					of contents as JavaScript objects. User agents can process and internalize the resulting structure
 					in whatever language and form is appropriate.</p>
 
-				<p>For the purposes of this algorithm, a <dfn>list element</dfn> is defined as either an [[!html]] <a
-						href="https://www.w3.org/TR/html/grouping-content.html#the-ol-element"><code>ol</code></a> or <a
+				<p>For the purposes of this algorithm, a <dfn>list element</dfn> is defined as either an
+						[[!html]]&#160;<a href="https://www.w3.org/TR/html/grouping-content.html#the-ol-element"
+							><code>ol</code></a> or <a
 						href="https://www.w3.org/TR/html/grouping-content.html#the-ul-element"><code>ul</code></a>
 					element.</p>
 
@@ -3624,7 +3667,7 @@ dictionary LocalizableString {
 											<li>the text string obtained from the descendant content (e.g., by
 												calculating the <a
 													href="https://www.w3.org/TR/accname-1.1/#mapping_additional_nd_te"
-													>accessible name</a> [[accname-1.1]] of the element).</li>
+													>accessible name</a>&#160;[[accname-1.1]] of the element).</li>
 										</ul>
 										<p>If the resulting value of <code>name</code> is an empty string (e.g., after
 											removing any presentational elements and trimming all leading and trailing
@@ -3874,7 +3917,8 @@ dictionary LocalizableString {
 													<li>the text string obtained from the descendant content (e.g., by
 														calculating the <a
 															href="https://www.w3.org/TR/accname-1.1/#mapping_additional_nd_te"
-															>accessible name</a> [[accname-1.1]] of the element).</li>
+															>accessible name</a>&#160;[[accname-1.1]] of the
+														element).</li>
 												</ul>
 												<p>If the resulting value of <code>name</code> is an empty string (e.g.,
 													after removing any presentational elements and trimming all leading
@@ -3984,27 +4028,27 @@ dictionary LocalizableString {
 
 			<section>
 				<h3>Simple Book</h3>
-				<p>A manifest for a simple book. The <a
+				<p>A manifest for a simple book. A <a
 						href="https://w3c.github.io/pub-manifest/experiments/separate_manifest/mobydick.jsonld">JSON
-						encoding of its canonical representation</a> of this manifest is also available.</p>
+						encoding of the canonical representation</a> of this manifest is also available.</p>
 				<pre class="example" data-include="experiments/separate_manifest/mobydick-simple.jsonld" data-include-format="text"></pre>
 			</section>
 
 			<section>
 				<h3>Single-Document Publication</h3>
-				<p>Example for an embedded manifest example. The <a
+				<p>Example for an embedded manifest example. A <a
 						href="https://w3c.github.io/pub-manifest/experiments/w3c_rec/simple-canonical.jsonld">JSON
-						encoding of its canonical representation</a> of the manifest is, as well as a <a
+						encoding of the canonical representation</a> of the manifest is also available, as well as a <a
 						href="https://github.com/w3c/pub-manifest/blob/master/experiments/w3c_rec/full_version.html"
-						>more elaborate version</a> for the same document are also available.</p>
+						>more elaborate version</a> for the same document.</p>
 				<pre class="example" data-include="experiments/w3c_rec/simple_version.html" data-include-format="text"></pre>
 			</section>
 
 			<section>
 				<h3>Audiobook</h3>
-				<p>A manifest for an audiobook. The <a
+				<p>A manifest for an audiobook. A <a
 						href="https://w3c.github.io/pub-manifest/experiments/audiobook/flatland-canonical.json">JSON
-						encoding of its canonical representation</a> of this manifest is also available.</p>
+						encoding of the canonical representation</a> of this manifest is also available.</p>
 				<pre class="example" data-include="experiments/audiobook/flatland.json" data-include-format="text"></pre>
 			</section>
 		</section>

--- a/index.html
+++ b/index.html
@@ -181,7 +181,7 @@
 
 					<dl>
 						<dt>
-							<a href="#informative-rel">informative resources</a>
+							<a href="#informative-rel">Informative resources</a>
 						</dt>
 						<dd>
 							<p>Informative resources are resources that contain additional information about the
@@ -190,7 +190,7 @@
 									>preview</a>.</p>
 						</dd>
 						<dt>
-							<a href="#structural-rel">structural resources</a>
+							<a href="#structural-rel">Structural resources</a>
 						</dt>
 						<dd>
 							<p>Structural resources are key meta structures of the publication, such as the <a


### PR DESCRIPTION
This PR is fairly large, but the bulk of the changes are purely editorial fixes. These include:

- fixes for language consistency between sections;
- consolidation of prose;
- spelling and grammar fixes;
- diversification of examples

The one change of note is to the required manifest properties. I noticed that we still listed title and reading order, but these are not required in the manifest. They are required in the canonical representation, as they always get compiled if not explicit. I've done my best to make the distinction between the manifest requirements and the WebIDL clear, but comments welcome. (See the changes to 2.2 and 2.3.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/54.html" title="Last updated on Sep 6, 2019, 11:56 AM UTC (fa54d7d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/54/364e5e7...fa54d7d.html" title="Last updated on Sep 6, 2019, 11:56 AM UTC (fa54d7d)">Diff</a>