### PR TITLE
Feature/add alternative

### DIFF
--- a/index.html
+++ b/index.html
@@ -2787,10 +2787,10 @@ enum ProgressionDirection {
 }</pre>
 							</details>
 						</li>
-
+	
 						<li>
 							<p>(<a href="#value-link"></a>) If <var>term</var> is a <a
-									href="#resource-categorization-properties">resource categorization property</a> and
+									href="#resource-categorization-properties">resource categorization property</a> or an <code>alternate</code> property, and
 								any value in the array in <var>current</var> is a string, convert each string
 									<var>str</var> to an object with the following properties:</p>
 							<ul>
@@ -3169,7 +3169,17 @@ enum ProgressionDirection {
 							<td>
 								<p>References to one or more reformulation(s) of the resource in alternative formats.</p>
 								<p>When specified, <code>encodingFormat</code> indicates the format of the reformulation.</p>
+								<p>Order is not significant.</p>
 								<p>OPTIONAL</p>
+								<p>One or more of:</p>
+										<ul>
+											<li>a string, representing the <a>URL</a> of the resource reformulation in an alternative format; or</li>
+											<li>an instance of a <a href="#publication-link-def"
+														><code>LinkedResource</code></a> object</li>
+										</ul>
+										<p>The order of items is <em>not significant</em>. Non-HTML resources SHOULD be expressed as
+												<code>LinkedResource</code> objects with their
+												<code>encodingFormat</code> values set.</p>
 							</td>
 							<td>
 								<p>One or more instances of <a href="#publication-link-def"><code>LinkedResource</code></a> objects.</p>
@@ -3196,16 +3206,34 @@ enum ProgressionDirection {
 }</pre>
 				</aside>
 
+				<aside class="example" title="A resource with its alternate formats">
+					<pre>{
+    "type":           "LinkedResource",
+    "url":            "chapter1.mp3",
+    "encodingFormat": "audio/mpeg",
+    "name":           "Chapter 1 - Loomings",
+    "alternate": [
+	"chapter1.html",
+	{
+		"type": "LinkedResource",
+		"url": "chapter1.json",
+		"encodingFormat": "application/vnd.wp-sync-media+json"
+		"length": 1669
+	}
+    ]
+}</pre>
+				</aside>
+
 				<pre class="idl">
 dictionary LinkedResource {
-    required DOMString           url;
-             DOMString           encodingFormat;
-             sequence&lt;LocalizableString>   name;
-             LocalizableString   description;
-             sequence&lt;DOMString> rel;
-             DOMString           integrity;
-             double              length;
-             sequence&lt;LinkedResource> alternate;
+    required DOMString                           url;
+             DOMString                           encodingFormat;
+             sequence&lt;LocalizableString>         name;
+             LocalizableString                   description;
+             sequence&lt;DOMString>                 rel;
+             DOMString                           integrity;
+             double                              length;
+             sequence&lt;LinkedResource>            alternate;
 };</pre>
 			</section>
 

--- a/index.html
+++ b/index.html
@@ -2790,7 +2790,7 @@ enum ProgressionDirection {
 	
 						<li>
 							<p>(<a href="#value-link"></a>) If <var>term</var> is a <a
-									href="#resource-categorization-properties">resource categorization property</a> or an <code>alternate</code> property, and
+									href="#resource-categorization-properties">resource categorization property</a> or an <a href="#dom-linkedresource-alternate"><code>alternate</code></a> property, and
 								any value in the array in <var>current</var> is a string, convert each string
 									<var>str</var> to an object with the following properties:</p>
 							<ul>

--- a/index.html
+++ b/index.html
@@ -2988,16 +2988,6 @@ enum ProgressionDirection {
 						</li>
 
 						<li>
-							<p>(<a href="#default-reading-order"></a> and <a href="#resource-list"></a>) For each entry
-								in <var>processed["readingOrder"]</var> and <var>processed["resources"]</var> with an
-									<var>alternative</var> property <var>P</var>, iterate each value of
-									<var>alternative</var>
-								<var>V</var>.</p>
-							<p>If <var>V["url"]</var> does not match the URL of a resource in the <a>resource list</a>,
-								remove <var>V</var> from <var>P</var> array and issue a warning.</p>
-						</li>
-
-						<li>
 							<p>(<a href="#resource-categorization-properties"></a>) For each <a
 									href="#resource-categorization-properties">resource categorization property</a>
 								<var>term</var>, check whether each object <var>P</var> in <var>processed[term]</var>

--- a/index.html
+++ b/index.html
@@ -3163,10 +3163,14 @@ enum ProgressionDirection {
 						<tr>
 							<td>
 								<code>
-									<dfn>alternative</dfn>
+									<dfn>alternate</dfn>
 								</code>
 							</td>
-							<td>A reference to a reformulation of the resource in an alternative format. OPTIONAL</td>
+							<td>
+								<p>References to one or more reformulation(s) of the resource in alternative formats.</p>
+								<p>When specified, <code>encodingFormat</code> indicates the format of the reformulation.</p>
+								<p>OPTIONAL</p>
+							</td>
 							<td>
 								<p>One or more instances of <a href="#publication-link-def"><code>LinkedResource</code></a> objects.</p>
 							</td>
@@ -3201,7 +3205,7 @@ dictionary LinkedResource {
              sequence&lt;DOMString> rel;
              DOMString           integrity;
              double              length;
-             sequence&lt;LinkedResource> alternative;
+             sequence&lt;LinkedResource> alternate;
 };</pre>
 			</section>
 

--- a/index.html
+++ b/index.html
@@ -3167,7 +3167,9 @@ enum ProgressionDirection {
 								</code>
 							</td>
 							<td>A reference to a reformulation of the resource in an alternative format. OPTIONAL</td>
-							<td>One or more valid URL strings&#160;[[!url]].</td>
+							<td>
+								<p>One or more instances of <a href="#publication-link-def"><code>LinkedResource</code></a> objects.</p>
+							</td>
 							<td>
 								<a href="#value-array">Array</a> of <a href="#value-link">Links</a>
 							</td>

--- a/index.html
+++ b/index.html
@@ -3179,7 +3179,7 @@ enum ProgressionDirection {
 							<td>A reference to a reformulation of the resource in an alternative format. OPTIONAL</td>
 							<td>One or more valid URL strings&#160;[[!url]].</td>
 							<td>
-								<a href="#value-array">Array</a> of <a href="#value-url">URLs</a>
+								<a href="#value-array">Array</a> of <a href="#value-link">Links</a>
 							</td>
 							<td> (None) </td>
 						</tr>
@@ -3209,7 +3209,7 @@ dictionary LinkedResource {
              sequence&lt;DOMString> rel;
              DOMString           integrity;
              double              length;
-             sequence&lt;DOMString> alternative;
+             sequence&lt;LinkedResource> alternative;
 };</pre>
 			</section>
 


### PR DESCRIPTION
Adds a property to LinkedResource called `alternate`. 

Addresses https://github.com/w3c/pub-manifest/issues/33


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marisademeglio/pub-manifest/pull/56.html" title="Last updated on Sep 9, 2019, 9:43 PM UTC (3afedcd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/56/cd05f1a...marisademeglio:3afedcd.html" title="Last updated on Sep 9, 2019, 9:43 PM UTC (3afedcd)">Diff</a>