### PR TITLE
Add basic dcterms:conformsTo example

### DIFF
--- a/index.html
+++ b/index.html
@@ -2124,13 +2124,13 @@ enum ProgressionDirection {
 								href="https://www.w3.org/TR/json-ld/#compact-iris">Compact IRIs</a>&#160;[[!json-ld]],
 							with prefixes defined as part of the context.</p>
 
-						<p class="note"> A prefix definition <code>dc</code> for [[dcterms]] is included in the context
+						<p class="note">A prefix definition <code>dcterms</code> for [[dcterms]] is included in the context
 							file of [[schema.org]]. This means that it is not necessary to add the prefix explicitly.
 							The same is true for a number of other public vocabularies; see the <a
 								href="https://schema.org/docs/jsonldcontext.json">schema.org context file</a> for
 							further details.</p>
 
-						<pre class="example" title="Usage of the schema.org 'copyrightYear' and 'copyrightHolder' terms, as an extension to the basic data">
+						<pre class="example" title="Extending the basic data using the schema.org 'copyrightYear' and 'copyrightHolder' terms.">
 {
 "@context"        : ["https://schema.org","https://www.w3.org/ns/pub-context"],
 "type"            : "TechArticle",
@@ -2143,14 +2143,24 @@ enum ProgressionDirection {
 }
 </pre>
 
-						<pre class="example" title="Usage of the Dublin Core 'subject' with the 2012 ACM Classification terms, as an extension to the basic data">
+						<pre class="example" title="Extending the basic data set using the Dublin Core 'subject' term with the 2012 ACM Classification terms.">
 {
 "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
 "type"       : "CreativeWork",
 &#8230;
 "id"         : "http://www.w3.org/TR/tabular-data-model/",
 "url"        : "http://www.w3.org/TR/2015/REC-tabular-data-model-20151217/",
-"dc:subject" : ["Web data description languages","Data integration","Data Exchange"],
+"dcterms:subject" : ["Web data description languages","Data integration","Data Exchange"],
+&#8230;
+}
+</pre>
+						
+						<pre class="example" title="Extending the basic data set using the Dublin Core 'conformsTo' term to identify the version of a standard a publication conforms to.">
+{
+"@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+"type"       : "CreativeWork",
+&#8230;
+"dcterms:conformsTo" : "https://example.org/publishing/standard-11",
 &#8230;
 }
 </pre>

--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
 				wg: "Publishing Working Group",
 				specStatus: "ED",
 				shortName: "pub-manifest",
-				previousPublishDate: "2019-08-27",
-				previousMaturity: "FPWD",
+				previousPublishDate: "2019-09-11",
+				previousMaturity: "WD",
 				edDraftURI: "https://w3c.github.io/pub-manifest/",
 				editors: [
 					{

--- a/index.html
+++ b/index.html
@@ -2123,12 +2123,26 @@ enum ProgressionDirection {
 							RECOMMENDED that such terms be included using <a
 								href="https://www.w3.org/TR/json-ld/#compact-iris">Compact IRIs</a>&#160;[[!json-ld]],
 							with prefixes defined as part of the context.</p>
-
-						<p class="note">A prefix definition <code>dcterms</code> for [[dcterms]] is included in the context
-							file of [[schema.org]]. This means that it is not necessary to add the prefix explicitly.
-							The same is true for a number of other public vocabularies; see the <a
-								href="https://schema.org/docs/jsonldcontext.json">schema.org context file</a> for
-							further details.</p>
+						
+						<pre class="example" title="Extending the basic data set using a vocabulary prefix declaration.">
+{
+"@context"   : [
+                    "https://schema.org",
+                    "https://www.w3.org/ns/pub-context",
+                    {"ex": "https://example.org/vocab"}
+               ],
+&#8230;
+"ex:region" : "North America",
+&#8230;
+}
+</pre>
+						
+						<p class="note">The <a href="https://schema.org/docs/jsonldcontext.json">schema.org context
+								file</a> [[schema.org]] defines a number of prefixes for commonly used vocabularies,
+							such as the Dublin Core Terms (`dcterms`) [[dcterms]] and Element Set (`dc`) [[dc11]], the
+							FOAF vocabulary (`foaf`) [[foaf]], and the Bibliographic Ontology (`bibo`) [[bibo]].
+							Properties from these vocabularies can be used without their prefixes having to be
+							declared.</p>
 
 						<pre class="example" title="Extending the basic data using the schema.org 'copyrightYear' and 'copyrightHolder' terms.">
 {
@@ -2154,7 +2168,7 @@ enum ProgressionDirection {
 &#8230;
 }
 </pre>
-						
+
 						<pre class="example" title="Extending the basic data set using the Dublin Core 'conformsTo' term to identify the version of a standard a publication conforms to.">
 {
 "@context"   : ["https://schema.org","https://www.w3.org/ns/pub-context"],


### PR DESCRIPTION
One question I had is that there was already an example of `dc:subject` but the note before the example incorrectly suggested `dc` maps to dcterms.

Did we actually want to include a dc element set example, or is my correcting the prefix to `dcterms` fine?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/59.html" title="Last updated on Sep 15, 2019, 3:18 PM UTC (7790daf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/59/a514e50...7790daf.html" title="Last updated on Sep 15, 2019, 3:18 PM UTC (7790daf)">Diff</a>