### PR TITLE
update local language declaration to include global language

### DIFF
--- a/index.html
+++ b/index.html
@@ -490,17 +490,24 @@ enum ProgressionDirection {
 					<p>It is possible to set the language locally for any natural language value in the manifest using a
 							<a href="#LocalizableString">localizable string</a>:</p>
 
-					<pre class="example" title="Setting the author name to French using a localizable string.">
+					<pre class="example" title="Providing the author name in English for a Chinese publication.">
 {
-    "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    "@context" : [
+        "https://schema.org",
+        "https://www.w3.org/ns/pub-context",
+        {"language": "cn"}
+    ],
     "type"     : "Book",
     &#8230;
     "author" : {
         "type"  : "Person",
-        "name" : {
-            "value"    : "Marcel Proust",
-            "language" : "fr"
-        }
+        "name" : [
+            "孔子",
+            {
+                "value"    : "Confucius",
+                "language" : "en"
+            }
+        ]
     }
 }
 </pre>
@@ -509,8 +516,8 @@ enum ProgressionDirection {
 							href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
 						tag</a>&#160;[[!bcp47]].</p>
 
-					<p>In such cases, the local declaration takes precedence over the <a
-							href="#manifest-lang-dir-global">global declaration</a>.</p>
+					<p>A local language declaration takes precedence over a <a href="#manifest-lang-dir-global">global
+							declaration</a>.</p>
 
 					<p class="note">It is <em>not</em> possible to set the direction explicitly for a specific value.
 						For more information, refer to <a href="#app-bidi-directionality"></a>.</p>
@@ -2120,7 +2127,7 @@ enum ProgressionDirection {
 							RECOMMENDED that such terms be included using <a
 								href="https://www.w3.org/TR/json-ld/#compact-iris">Compact IRIs</a>&#160;[[!json-ld]],
 							with prefixes defined as part of the context.</p>
-						
+
 						<pre class="example" title="Extending the basic data set using a vocabulary prefix declaration.">
 {
 "@context"   : [
@@ -2133,7 +2140,7 @@ enum ProgressionDirection {
 &#8230;
 }
 </pre>
-						
+
 						<p class="note">The <a href="https://schema.org/docs/jsonldcontext.json">schema.org context
 								file</a> [[schema.org]] defines a number of prefixes for commonly used vocabularies,
 							such as the Dublin Core Terms (`dcterms`) [[dcterms]] and Element Set (`dc`) [[dc11]], the

--- a/index.html
+++ b/index.html
@@ -495,7 +495,7 @@ enum ProgressionDirection {
     "@context" : [
         "https://schema.org",
         "https://www.w3.org/ns/pub-context",
-        {"language": "cn"}
+        {"language": "zh"}
     ],
     "type"     : "Book",
     &#8230;


### PR DESCRIPTION
This PR should fix #66. It updates the local language example to also show the global language that is being overridden, so the value of `name` is an array.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/70.html" title="Last updated on Sep 18, 2019, 12:12 AM UTC (1e0fbbf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/70/fc0b219...1e0fbbf.html" title="Last updated on Sep 18, 2019, 12:12 AM UTC (1e0fbbf)">Diff</a>