### PR TITLE
Move object definitions from appendix

### DIFF
--- a/index.html
+++ b/index.html
@@ -316,19 +316,19 @@ dictionary PublicationManifest {
              sequence&lt;DOMString>         accessibilityFeature;
              sequence&lt;DOMString>         accessibilityHazard;
              LocalizableString           accessibilitySummary;
-             sequence&lt;CreatorInfo>       artist;
-             sequence&lt;CreatorInfo>       author;
-             sequence&lt;CreatorInfo>       colorist;
-             sequence&lt;CreatorInfo>       contributor;
-             sequence&lt;CreatorInfo>       creator;
-             sequence&lt;CreatorInfo>       editor;
-             sequence&lt;CreatorInfo>       illustrator;
-             sequence&lt;CreatorInfo>       inker;
-             sequence&lt;CreatorInfo>       letterer;
-             sequence&lt;CreatorInfo>       penciler;
-             sequence&lt;CreatorInfo>       publisher;
-             sequence&lt;CreatorInfo>       readBy;
-             sequence&lt;CreatorInfo>       translator;
+             sequence&lt;Entity>            artist;
+             sequence&lt;Entity>            author;
+             sequence&lt;Entity>            colorist;
+             sequence&lt;Entity>            contributor;
+             sequence&lt;Entity>            creator;
+             sequence&lt;Entity>            editor;
+             sequence&lt;Entity>            illustrator;
+             sequence&lt;Entity>            inker;
+             sequence&lt;Entity>            letterer;
+             sequence&lt;Entity>            penciler;
+             sequence&lt;Entity>            publisher;
+             sequence&lt;Entity>            readBy;
+             sequence&lt;Entity>            translator;
              sequence&lt;DOMString>         url;
              DOMString                   duration;
              TextDirection               direction;
@@ -353,6 +353,46 @@ enum ProgressionDirection {
     "rtl"
 };
 </pre>
+					<section id="LinkedResource">
+						<h3><code>LinkedResource</code> Dictionary</h3>
+
+						<pre class="idl">
+dictionary LinkedResource {
+    required DOMString                           url;
+             DOMString                           encodingFormat;
+             sequence&lt;LocalizableString>         name;
+             LocalizableString                   description;
+             sequence&lt;DOMString>                 rel;
+             DOMString                           integrity;
+             double                              length;
+             sequence&lt;LinkedResource>            alternate;
+};</pre>
+					</section>
+
+					<section id="Entity">
+						<h3><code>Entity</code> Dictionary</h3>
+
+						<pre class="idl">
+dictionary Entity {
+             sequence&lt;DOMString>         type;
+    required sequence&lt;LocalizableString> name;
+             DOMString                   id;
+             DOMString                   url;
+             sequence&lt;DOMString>         identifier;
+};
+</pre>
+					</section>
+
+					<section id="LocalizableString">
+						<h3><code>LocalizableString</code> Dictionary</h3>
+
+						<pre class="idl">
+dictionary LocalizableString {
+    required DOMString                   value;
+             DOMString                   language;
+};
+</pre>
+					</section>
 				</section>
 			</section>
 
@@ -628,14 +668,58 @@ enum ProgressionDirection {
 							<ul>
 								<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
 									value; or</li>
-								<li>a [[!json]]&#160;<a href="https://tools.ietf.org/html/rfc4627#section-2.2"
-										>object</a> with a <code>value</code> property containing a the property's text
-									and a <code>language</code> property that identifies the language of the text.</li>
+								<li>A <code>LocalizableString</code>.</li>
 							</ul>
 
 							<p>A single string value represents an implied object whose <code>value</code> property is
 								the string's text and whose language is determined from other information in the
 								manifest.</p>
+
+							<p>A <code>LocalizableString</code> is a [[!json]]&#160;<a
+									href="https://tools.ietf.org/html/rfc4627#section-2.2">object</a> consisting of the
+								following properties:</p>
+
+							<table class="zebra" data-dfn-for="LocalizableString">
+								<thead>
+									<tr>
+										<th>Term</th>
+										<th>Description</th>
+										<th>Required Value</th>
+										<th>Value Type</th>
+										<th>[[!schema.org]] Mapping</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>
+											<code>
+												<dfn>value</dfn>
+											</code>
+										</td>
+										<td>The value of the localizable string. REQUIRED.</td>
+										<td>Text.</td>
+										<td><a href="#value-literal">Literal</a></td>
+										<td>(None)</td>
+									</tr>
+									<tr>
+										<td>
+											<code>
+												<dfn>language</dfn>
+											</code>
+										</td>
+										<td>The language of the value. OPTIONAL.</td>
+										<td>A <a href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed
+												language tag</a>&#160;[[!bcp47]].</td>
+										<td><a href="#value-literal">Literal</a></td>
+										<td>(None)</td>
+									</tr>
+								</tbody>
+							</table>
+
+							<pre class="example">{
+    "value"    : "",
+    "language" : ""
+}</pre>
 						</section>
 
 						<section id="value-object-entity">
@@ -648,12 +732,113 @@ enum ProgressionDirection {
 							<ul>
 								<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
 									value; or</li>
-								<li>a <a href="#CreatorInfo"><code>CreatorInfo</code> object</a>.</li>
+								<li>an <code>Entity</code>.</li>
 							</ul>
 
-							<p>A single string value represents an instance of a <code>CreatorInfo</code> object whose
+							<p>A single string value represents an instance of an <code>Entity</code> object whose
 									<code>name</code> property is the string's text and whose <code>type</code> is
 								assumed to be <a href="https://schema.org/Person">Person</a>&#160;[[!schema.org]].</p>
+
+							<p>An <code>Entity</code> is defined as an instance of either the [[!schema.org]] <a
+									href="https://schema.org/Person"><code>Person</code></a> or <a
+									href="https://schema.org/Organization"><code>Organization</code></a> type with the
+								following mininmal property set:</p>
+
+							<table class="zebra" data-dfn-for="Entity">
+								<thead>
+									<tr>
+										<th>Term</th>
+										<th>Description</th>
+										<th>Required Value</th>
+										<th>Value Type</th>
+										<th>[[!schema.org]] Mapping</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>
+											<code>
+												<dfn>type</dfn>
+											</code>
+										</td>
+										<td>The type of creator. OPTIONAL</td>
+										<td>One or more Text. Sequence MUST include "<code>Person</code>" or
+												"<code>Organization</code>".</td>
+										<td>
+											<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
+										</td>
+										<td>(None)</td>
+									</tr>
+									<tr>
+										<td>
+											<code>
+												<dfn>name</dfn>
+											</code>
+										</td>
+										<td>Name of the creator. REQUIRED.</td>
+										<td>One or more Text.</td>
+										<td>
+											<a href="#value-array">Array</a> of <a href="#value-localizable-string"
+												>Localizable Strings</a>
+										</td>
+										<td>
+											<a href="https://schema.org/name">
+												<code>name</code>
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td>
+											<code>
+												<dfn>id</dfn>
+											</code>
+										</td>
+										<td>A canonical identifier associated with the creator. OPTIONAL.</td>
+										<td>A URL record&#160;[[!url]].</td>
+										<td>
+											<a href="#value-id">Identifier</a>
+										</td>
+										<td> (None) </td>
+									</tr>
+									<tr>
+										<td>
+											<code>
+												<dfn>url</dfn>
+											</code>
+										</td>
+										<td>An address associated with the creator. OPTIONAL.</td>
+										<td>A valid URL string&#160;[[!url]].</td>
+										<td>
+											<a href="#value-url">URL</a>
+										</td>
+										<td>
+											<a href="https://schema.org/url">
+												<code>url</code>
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td>
+											<code>
+												<dfn>identifier</dfn>
+											</code>
+										</td>
+										<td>An identifier associated with the creator (e.g., ORCID). OPTIONAL.</td>
+										<td>One or more text(s).</td>
+										<td>
+											<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
+										</td>
+										<td>
+											<a href="https://schema.org/identifier">
+												<code>identifier</code>
+											</a>
+										</td>
+									</tr>
+								</tbody>
+							</table>
+
+							<p>Note that user agents MAY interpret a wider range of creator properties defined by
+								Schema.org than the ones in the preceding table.</p>
 
 							<aside class="example" title="Using a string instead of a Person object.">
 								<p>The following author name is expressed as a string:</p>
@@ -677,8 +862,8 @@ enum ProgressionDirection {
 							</aside>
 						</section>
 
-						<section id="value-link">
-							<h5>Links</h5>
+						<section id="value-linked-resource">
+							<h5>Linked Resource</h5>
 
 							<p>When a manifest property links to one or more resources, it MUST be expressed either
 								as:</p>
@@ -686,10 +871,225 @@ enum ProgressionDirection {
 							<ol>
 								<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
 									encoding the <a>URL</a> of the resources; or</li>
-								<li>an instance of a <a href="#publication-link-def"><code>LinkedResource</code>
-										object</a> that can be used to express the URL, the media type, and other
-									characteristics of the target resource.</li>
+								<li>an instance of a <code>LinkedResource</code>.</li>
 							</ol>
+
+							<p>A string value represents an implied <code>LinkedResource</code> object whose
+									<code>url</code> property is set to the string value.</p>
+
+							<p>A <code>LinkedResource</code> is object is defined as follows:</p>
+
+							<table class="zebra" data-dfn-for="LinkedResource">
+								<thead>
+									<tr>
+										<th>Term</th>
+										<th>Description</th>
+										<th>Required Value</th>
+										<th>Value Type</th>
+										<th>[[!schema.org]] Mapping</th>
+									</tr>
+								</thead>
+								<tbody>
+									<tr>
+										<td>
+											<code>
+												<dfn>type</dfn>
+											</code>
+										</td>
+										<td>The type of resource. OPTIONAL</td>
+										<td>One or more Text. Sequence MUST include "<code>LinkedResource</code>".</td>
+										<td>
+											<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
+										</td>
+										<td>(None)</td>
+									</tr>
+									<tr>
+										<td>
+											<code>
+												<dfn>url</dfn>
+											</code>
+										</td>
+										<td>Location of the resource. REQUIRED.</td>
+										<td>A valid URL string&#160;[[!url]]. Refer to the property definitions that
+											accept this type for additional restrictions.</td>
+										<td>
+											<a href="#value-url">URL</a>
+										</td>
+										<td>
+											<a href="https://schema.org/url">
+												<code>url</code>
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td>
+											<code>
+												<dfn>encodingFormat</dfn>
+											</code>
+										</td>
+										<td>Media type of the resource (e.g., <code>text/html</code>). OPTIONAL.</td>
+										<td>MIME Media Type&#160;[[!rfc2046]].</td>
+										<td>
+											<a href="#value-literal">Literal</a>
+										</td>
+										<td>
+											<a href="https://schema.org/encodingFormat">
+												<code>encodingFormat</code>
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td>
+											<code>
+												<dfn>name</dfn>
+											</code>
+										</td>
+										<td>Name of the item. OPTIONAL.</td>
+										<td>One or more Text items.</td>
+										<td>
+											<a href="#value-array">Array</a> of <a href="#value-localizable-string"
+												>Localizable Strings</a>
+										</td>
+										<td>
+											<a href="https://schema.org/name">
+												<code>name</code>
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td>
+											<code>
+												<dfn>description</dfn>
+											</code>
+										</td>
+										<td>Description of the item. OPTIONAL.</td>
+										<td>Text.</td>
+										<td>
+											<a href="#value-localizable-string">Localizable String</a>
+										</td>
+										<td>
+											<a href="https://schema.org/description">
+												<code>description</code>
+											</a>
+										</td>
+									</tr>
+									<tr>
+										<td>
+											<code>
+												<dfn>rel</dfn>
+											</code>
+										</td>
+										<td>The relation of the resource to the publication. OPTIONAL.</td>
+										<td>
+											<p>One or more <a href="#manifest-rel">relations</a>. The values are either
+												the relevant relation terms of the IANA link
+												registry&#160;[[!iana-link-relations]], or specially-defined URLs if no
+												suitable link registry item exists.</p>
+										</td>
+										<td>
+											<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
+										</td>
+										<td>(None)</td>
+									</tr>
+									<tr>
+										<td>
+											<code><dfn>integrity</dfn></code>
+										</td>
+										<td>A cryptographic hashing of the resource that allows its integrity to be
+											verified. OPTIONAL.</td>
+										<td><p>One or more whitespace-separated sets of <a
+													href="https://www.w3.org/TR/SRI/#dfn-integrity-metadata">integrity
+													metadata</a>&#160;[[!sri]]. The value MUST conform to the <a
+													href="https://www.w3.org/TR/SRI/#the-integrity-attribute">metadata
+													definition</a>&#160;[[!sri]].</p>
+											<p>Refer to [[!sri]] for the <a
+													href="https://www.w3.org/TR/SRI/#cryptographic-hash-functions">list
+													of cryptographic hashing functions</a> that user agents are expected
+												to support.</p>
+										</td>
+										<td>
+											<a href="#value-literal">Literal</a>
+										</td>
+										<td>(None)</td>
+									</tr>
+									<tr>
+										<td>
+											<code>
+												<dfn>length</dfn>
+											</code>
+										</td>
+										<td>The total length of a time-based media resource in (possibly fractional)
+											seconds. OPTIONAL</td>
+										<td>Number</td>
+										<td>
+											<a href="#value-number">Number</a>
+										</td>
+										<td>(None)</td>
+									</tr>
+									<tr>
+										<td>
+											<code>
+												<dfn>alternate</dfn>
+											</code>
+										</td>
+										<td>
+											<p>References to one or more reformulation(s) of the resource in alternative
+												formats.</p>
+											<p>When specified, <code>encodingFormat</code> indicates the format of the
+												reformulation.</p>
+											<p>Order is not significant.</p>
+											<p>OPTIONAL</p>
+											<p>One or more of:</p>
+											<ul>
+												<li>a string, representing the <a>URL</a> of the resource reformulation
+													in an alternative format; or</li>
+												<li>an instance of a <a href="#publication-link-def"
+															><code>LinkedResource</code></a> object</li>
+											</ul>
+											<p>The order of items is <em>not significant</em>. Non-HTML resources SHOULD
+												be expressed as <code>LinkedResource</code> objects with their
+													<code>encodingFormat</code> values set.</p>
+										</td>
+										<td>
+											<p>One or more instances of <a href="#publication-link-def"
+														><code>LinkedResource</code></a> objects.</p>
+										</td>
+										<td>
+											<a href="#value-array">Array</a> of <a href="#value-linked-resource">Linked
+												Resources</a>
+										</td>
+										<td> (None) </td>
+									</tr>
+								</tbody>
+							</table>
+
+							<p>Although user agent support for the <code>integrity</code> property is OPTIONAL, user
+								agents that support cryptographic hashing comparisons using this property MUST do so in
+								accordance with [[!sri]].</p>
+
+							<pre class="example" title="A resource with a SHA-256 hashing of its content.">{
+    "type"           : "LinkedResource",
+    "url"            : "chapter1.html",
+    "encodingFormat" : "text/html",
+    "name"           : "Chapter 1 - Loomings",
+    "integrity"      : "sha256-13AE04E21177BABEDFDE721577615A638341F963731EA936BBB8C3862F57CDFC"
+}</pre>
+
+							<pre class="example" title="A resource with its alternate formats.">{
+    "type"           : "LinkedResource",
+    "url"            : "chapter1.mp3",
+    "encodingFormat" : "audio/mpeg",
+    "name"           : "Chapter 1 - Loomings",
+    "alternate"      : [
+        "chapter1.html",
+        {
+            "type": "LinkedResource",
+            "url": "chapter1.json",
+            "encodingFormat": "application/vnd.wp-sync-media+json",
+            "length": 1669
+        }
+    ]
+}</pre>
 
 							<p>A string value represents an implied <code>LinkedResource</code> object whose
 									<code>url</code> property is set to the string value.</p>
@@ -1332,8 +1732,8 @@ enum ProgressionDirection {
 						<p>When compiling each set of creator information from a [[!schema.org]] <a
 								href="https://schema.org/Person"><code>Person</code></a> or <a
 								href="https://schema.org/Organization"><code>Organization</code></a> type, user agents
-							MUST retain the properties defined for the <a href="#CreatorInfo">CreatorInfo type</a>, when
-							available.</p>
+							MUST retain the properties defined for the <a href="#value-object-entity">Entity type</a>,
+							when available.</p>
 
 						<p>The manifest MAY include more than one of each type of creator.</p>
 
@@ -1750,7 +2150,8 @@ enum ProgressionDirection {
 											><code>LinkedResource</code></a>.</p>
 									</td>
 									<td>
-										<a href="#value-array">Array</a> of <a href="#value-link">Links</a>
+										<a href="#value-array">Array</a> of <a href="#value-linked-resource">Linked
+											Resources</a>
 									</td>
 									<td>(None)</td>
 								</tr>
@@ -1841,7 +2242,8 @@ enum ProgressionDirection {
 											><code>LinkedResource</code></a>.</p>
 									</td>
 									<td>
-										<a href="#value-array">Array</a> of <a href="#value-link">Links</a>
+										<a href="#value-array">Array</a> of <a href="#value-linked-resource">Linked
+											Resources</a>
 									</td>
 									<td>(None)</td>
 								</tr>
@@ -1932,7 +2334,8 @@ enum ProgressionDirection {
 											><code>LinkedResource</code></a>.</p>
 									</td>
 									<td>
-										<a href="#value-array">Array</a> of <a href="#value-link">Links</a>
+										<a href="#value-array">Array</a> of <a href="#value-linked-resource">Linked
+											Resources</a>
 									</td>
 									<td>(None)</td>
 								</tr>
@@ -2682,7 +3085,7 @@ enum ProgressionDirection {
 							</details>
 						</li>
 						<li id="processing-expansion-links">
-							<p>(<a href="#value-link"></a>) If <var>term</var> is a <a
+							<p>(<a href="#value-linked-resource"></a>) If <var>term</var> is a <a
 									href="#resource-categorization-properties">resource categorization property</a> or
 								an <a href="#dom-linkedresource-alternate"><code>alternate</code></a> property, and any
 								value in the array in <var>current</var> is a string, convert each string <var>str</var>
@@ -2974,418 +3377,6 @@ enum ProgressionDirection {
 
 			<p>More specific security and privacy considerations are left to each profile to detail, as these will vary
 				depending on the nature of the <a>digital publication</a> format.</p>
-		</section>
-		<section id="app-custom-types" class="appendix">
-			<h2>Custom Type Definition</h2>
-
-			<section id="LinkedResource">
-				<h3><code>LinkedResource</code> Definition</h3>
-
-				<p id="publication-link-def">This specification defines a new type for links called
-							<code><dfn>LinkedResource</dfn></code>. It consists of the following properties:</p>
-
-				<table class="zebra" data-dfn-for="LinkedResource">
-					<thead>
-						<tr>
-							<th>Term</th>
-							<th>Description</th>
-							<th>Required Value</th>
-							<th>Value Type</th>
-							<th>[[!schema.org]] Mapping</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td>
-								<code>
-									<dfn>type</dfn>
-								</code>
-							</td>
-							<td>The type of resource. OPTIONAL</td>
-							<td>One or more Text. Sequence MUST include "<code>LinkedResource</code>".</td>
-							<td>
-								<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
-							</td>
-							<td>(None)</td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>url</dfn>
-								</code>
-							</td>
-							<td>Location of the resource. REQUIRED.</td>
-							<td>A valid URL string&#160;[[!url]]. Refer to the property definitions that accept this
-								type for additional restrictions.</td>
-							<td>
-								<a href="#value-url">URL</a>
-							</td>
-							<td>
-								<a href="https://schema.org/url">
-									<code>url</code>
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>encodingFormat</dfn>
-								</code>
-							</td>
-							<td>Media type of the resource (e.g., <code>text/html</code>). OPTIONAL.</td>
-							<td>MIME Media Type&#160;[[!rfc2046]].</td>
-							<td>
-								<a href="#value-literal">Literal</a>
-							</td>
-							<td>
-								<a href="https://schema.org/encodingFormat">
-									<code>encodingFormat</code>
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>name</dfn>
-								</code>
-							</td>
-							<td>Name of the item. OPTIONAL.</td>
-							<td>One or more Text items.</td>
-							<td>
-								<a href="#value-array">Array</a> of <a href="#value-localizable-string">Localizable
-									Strings</a>
-							</td>
-							<td>
-								<a href="https://schema.org/name">
-									<code>name</code>
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>description</dfn>
-								</code>
-							</td>
-							<td>Description of the item. OPTIONAL.</td>
-							<td>Text.</td>
-							<td>
-								<a href="#value-localizable-string">Localizable String</a>
-							</td>
-							<td>
-								<a href="https://schema.org/description">
-									<code>description</code>
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>rel</dfn>
-								</code>
-							</td>
-							<td>The relation of the resource to the publication. OPTIONAL.</td>
-							<td>
-								<p>One or more <a href="#manifest-rel">relations</a>. The values are either the relevant
-									relation terms of the IANA link registry&#160;[[!iana-link-relations]], or
-									specially-defined URLs if no suitable link registry item exists.</p>
-							</td>
-							<td>
-								<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
-							</td>
-							<td>(None)</td>
-						</tr>
-						<tr>
-							<td>
-								<code><dfn>integrity</dfn></code>
-							</td>
-							<td>A cryptographic hashing of the resource that allows its integrity to be verified.
-								OPTIONAL.</td>
-							<td><p>One or more whitespace-separated sets of <a
-										href="https://www.w3.org/TR/SRI/#dfn-integrity-metadata">integrity
-									metadata</a>&#160;[[!sri]]. The value MUST conform to the <a
-										href="https://www.w3.org/TR/SRI/#the-integrity-attribute">metadata
-										definition</a>&#160;[[!sri]].</p>
-								<p>Refer to [[!sri]] for the <a
-										href="https://www.w3.org/TR/SRI/#cryptographic-hash-functions">list of
-										cryptographic hashing functions</a> that user agents are expected to
-									support.</p>
-							</td>
-							<td>
-								<a href="#value-literal">Literal</a>
-							</td>
-							<td>(None)</td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>length</dfn>
-								</code>
-							</td>
-							<td>The total length of a time-based media resource in (possibly fractional) seconds.
-								OPTIONAL</td>
-							<td>Number</td>
-							<td>
-								<a href="#value-number">Number</a>
-							</td>
-							<td>(None)</td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>alternate</dfn>
-								</code>
-							</td>
-							<td>
-								<p>References to one or more reformulation(s) of the resource in alternative
-									formats.</p>
-								<p>When specified, <code>encodingFormat</code> indicates the format of the
-									reformulation.</p>
-								<p>Order is not significant.</p>
-								<p>OPTIONAL</p>
-								<p>One or more of:</p>
-								<ul>
-									<li>a string, representing the <a>URL</a> of the resource reformulation in an
-										alternative format; or</li>
-									<li>an instance of a <a href="#publication-link-def"><code>LinkedResource</code></a>
-										object</li>
-								</ul>
-								<p>The order of items is <em>not significant</em>. Non-HTML resources SHOULD be
-									expressed as <code>LinkedResource</code> objects with their
-										<code>encodingFormat</code> values set.</p>
-							</td>
-							<td>
-								<p>One or more instances of <a href="#publication-link-def"
-										><code>LinkedResource</code></a> objects.</p>
-							</td>
-							<td>
-								<a href="#value-array">Array</a> of <a href="#value-link">Links</a>
-							</td>
-							<td> (None) </td>
-						</tr>
-					</tbody>
-				</table>
-
-				<p>Although user agent support for the <code>integrity</code> property is OPTIONAL, user agents that
-					support cryptographic hashing comparisons using this property MUST do so in accordance with
-					[[!sri]].</p>
-
-				<pre class="example" title="A resource with a SHA-256 hashing of its content.">{
-    "type"           : "LinkedResource",
-    "url"            : "chapter1.html",
-    "encodingFormat" : "text/html",
-    "name"           : "Chapter 1 - Loomings",
-    "integrity"      : "sha256-13AE04E21177BABEDFDE721577615A638341F963731EA936BBB8C3862F57CDFC"
-}</pre>
-
-				<pre class="example" title="A resource with its alternate formats.">{
-    "type"           : "LinkedResource",
-    "url"            : "chapter1.mp3",
-    "encodingFormat" : "audio/mpeg",
-    "name"           : "Chapter 1 - Loomings",
-    "alternate"      : [
-        "chapter1.html",
-        {
-            "type": "LinkedResource",
-            "url": "chapter1.json",
-            "encodingFormat": "application/vnd.wp-sync-media+json",
-            "length": 1669
-        }
-    ]
-}</pre>
-
-				<pre class="idl">
-dictionary LinkedResource {
-    required DOMString                           url;
-             DOMString                           encodingFormat;
-             sequence&lt;LocalizableString>         name;
-             LocalizableString                   description;
-             sequence&lt;DOMString>                 rel;
-             DOMString                           integrity;
-             double                              length;
-             sequence&lt;LinkedResource>            alternate;
-};</pre>
-			</section>
-
-			<section id="CreatorInfo">
-				<h3><code>CreatorInfo</code> Definition</h3>
-
-				<p id="creatorinfo-link-def">This specification defines a new type for <a href="#creators">creators</a>
-					called <code><dfn>CreatorInfo</dfn></code>. It consists of the following properties:</p>
-
-				<table class="zebra" data-dfn-for="CreatorInfo">
-					<thead>
-						<tr>
-							<th>Term</th>
-							<th>Description</th>
-							<th>Required Value</th>
-							<th>Value Type</th>
-							<th>[[!schema.org]] Mapping</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td>
-								<code>
-									<dfn>type</dfn>
-								</code>
-							</td>
-							<td>The type of creator. OPTIONAL</td>
-							<td>One or more Text. Sequence MUST include "<code>Person</code>" or
-									"<code>Organization</code>".</td>
-							<td>
-								<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
-							</td>
-							<td>(None)</td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>name</dfn>
-								</code>
-							</td>
-							<td>Name of the creator. REQUIRED.</td>
-							<td>One or more Text.</td>
-							<td>
-								<a href="#value-array">Array</a> of <a href="#value-localizable-string">Localizable
-									Strings</a>
-							</td>
-							<td>
-								<a href="https://schema.org/name">
-									<code>name</code>
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>id</dfn>
-								</code>
-							</td>
-							<td>A canonical identifier associated with the creator. OPTIONAL.</td>
-							<td>A URL record&#160;[[!url]].</td>
-							<td>
-								<a href="#value-id">Identifier</a>
-							</td>
-							<td> (None) </td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>url</dfn>
-								</code>
-							</td>
-							<td>An address associated with the creator. OPTIONAL.</td>
-							<td>A valid URL string&#160;[[!url]].</td>
-							<td>
-								<a href="#value-url">URL</a>
-							</td>
-							<td>
-								<a href="https://schema.org/url">
-									<code>url</code>
-								</a>
-							</td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>identifier</dfn>
-								</code>
-							</td>
-							<td>An identifier associated with the creator (e.g., ORCID). OPTIONAL.</td>
-							<td>One or more text(s).</td>
-							<td>
-								<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
-							</td>
-							<td>
-								<a href="https://schema.org/identifier">
-									<code>identifier</code>
-								</a>
-							</td>
-						</tr>
-					</tbody>
-				</table>
-
-				<p>Note that user agents MAY interpret a wider range of creator properties defined by Schema.org than
-					the ones in the preceding table.</p>
-
-				<pre class="idl">
-dictionary CreatorInfo {
-             sequence&lt;DOMString>         type;
-    required sequence&lt;LocalizableString> name;
-             DOMString                   id;
-             DOMString                   url;
-             sequence&lt;DOMString>         identifier;
-};
-</pre>
-			</section>
-
-			<section id="LocalizableString">
-				<h3><code>LocalizableString</code> Definition</h3>
-
-				<p id="localizablestring-link-def">This specification defines a new type for <a
-						href="#value-localizable-string">localizable strings</a> called <code><dfn
-							data-lt="localizable string">LocalizableString</dfn></code>. It consists of the following
-					properties:</p>
-
-				<table class="zebra" data-dfn-for="LocalizableString">
-					<thead>
-						<tr>
-							<th>Term</th>
-							<th>Description</th>
-							<th>Required Value</th>
-							<th>Value Type</th>
-							<th>[[!schema.org]] Mapping</th>
-						</tr>
-					</thead>
-					<tbody>
-						<tr>
-							<td>
-								<code>
-									<dfn>type</dfn>
-								</code>
-							</td>
-							<td>The type of string. OPTIONAL</td>
-							<td>One or more Text. Sequence MUST include "<code>LocalizableString</code>".</td>
-							<td>
-								<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
-							</td>
-							<td>(None)</td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>value</dfn>
-								</code>
-							</td>
-							<td>The value of the localizable string. REQUIRED.</td>
-							<td>Text.</td>
-							<td><a href="#value-literal">Literal</a></td>
-							<td>(None)</td>
-						</tr>
-						<tr>
-							<td>
-								<code>
-									<dfn>language</dfn>
-								</code>
-							</td>
-							<td>The language of the value. OPTIONAL.</td>
-							<td>A <a href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
-								tag</a>&#160;[[!bcp47]].</td>
-							<td><a href="#value-literal">Literal</a></td>
-							<td>(None)</td>
-						</tr>
-					</tbody>
-				</table>
-
-				<pre class="idl">
-dictionary LocalizableString {
-             sequence&lt;DOMString>         type;
-    required DOMString                   value;
-             DOMString                   language;
-};
-</pre>
-			</section>
 		</section>
 		<section id="app-toc-structure" class="appendix">
 			<h2>Machine-Processable Table of Contents</h2>

--- a/schema/localizable-object.schema.json
+++ b/schema/localizable-object.schema.json
@@ -4,23 +4,6 @@
     "title": "Localizable String Object",
     "type": "object",
     "properties": {
-        "type": {
-            "anyOf": [
-                {
-                    "type": "string",
-                    "const": "LocalizableString"
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    },
-                    "contains": {
-                        "const": "LocalizableString"
-                    }
-                }
-            ]
-        },
         "value": {
             "type": "string"
         },


### PR DESCRIPTION
This is an attempt to resolve #64. It makes the following changes:

- object definitions are moved from the appendix to their corresponding value categories in 2.6.2.
- webidl dictionary definitions are made subsections of the PublicationManifest declaration
- CreatorInfo is changed to Entity to avoid the current proliferation of names for things - it is also explained that it is only a placeholder for Person or Organization
- Links (value category) is changed to Linked Resources per previous item
- the `type` property is removed from LocalizableString

Does this improve the clarity @BigBlueHat @iherman ?