### PR TITLE
Add manifest linking requirement to the extension requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -2374,8 +2374,7 @@ enum ProgressionDirection {
 			<section id="manifest-link">
 				<h3>Linking</h3>
 
-				<p>If a <a>digital publication</a> format uses links to discover a manifest, the links MUST take one or
-					both of the following forms:</p>
+				<p>Links to the manifest MUST take one or both of the following forms:</p>
 
 				<ul>
 					<li>
@@ -2451,11 +2450,13 @@ enum ProgressionDirection {
 			<section id="mod-compat">
 				<h3>Compatibility Requirements</h3>
 
-				<p> In order for a <a>digital publication</a> format to be compatible with this specification, following
-					conditions MUST be met: </p>
+				<p> In order for a <a>digital publication</a> format to be compatible with this specification, the
+					following conditions MUST be met: </p>
 
 				<ol>
 					<li>It MUST adhere to the manifest format requirements defined in this specification.</li>
+					<li>One or both <a href="#manifest-link">linking methods</a> MUST be used in the discovery of the
+						manifest.</li>
 					<li>The generic processing steps described in <a href="#manifest-processing"></a> MUST remain valid
 						for the extended manifest. To achieve this, and if new terms are added to the general manifest,
 						then: <ul>


### PR DESCRIPTION
An attempt to resolve #63. Requires the profiles use one of the linking methods in the discovery of the manifest.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/77.html" title="Last updated on Sep 25, 2019, 11:43 AM UTC (ac4f1b6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/77/023dcd2...ac4f1b6.html" title="Last updated on Sep 25, 2019, 11:43 AM UTC (ac4f1b6)">Diff</a>