### PR TITLE
Remove requirement that all URLs dereference

### DIFF
--- a/index.html
+++ b/index.html
@@ -726,9 +726,7 @@ enum ProgressionDirection {
 							string</a>&#160;[[!url]].</p>
 
 						<p>Manifest URLs are restricted to only the <code>http</code> and <code>https</code>
-							<a href="https://url.spec.whatwg.org/#concept-url-scheme">schemes</a>&#160;[[!url]]. URLs
-							MUST dereference to a resource, although user agents are not required to dereference all
-							URLs in the manifest.</p>
+							<a href="https://url.spec.whatwg.org/#concept-url-scheme">schemes</a>&#160;[[!url]].</p>
 
 						<p>In the case of <a href="https://url.spec.whatwg.org/#relative-url-string">relative-URL
 								strings</a>, these are resolved to <a


### PR DESCRIPTION
Fixes #67


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/78.html" title="Last updated on Sep 23, 2019, 11:39 PM UTC (e7ff0ed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/78/1b2c35c...e7ff0ed.html" title="Last updated on Sep 23, 2019, 11:39 PM UTC (e7ff0ed)">Diff</a>