### PR TITLE
Add "List of Requirements" to sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,20 @@
 		<script src="common/js/biblio.js" class="remove"></script>
 		<script src="common/js/pub.js" class="remove"></script>
 		<script src="common/js/idllink.js" class="remove"></script>
+		<script src="https://unpkg.com/reqlist/lib/reqlist.js" class="remove"></script>
+		<link href="https://unpkg.com/reqlist/lib/reqlist.css" class="remove" rel="stylesheet" type="text/css" />
 		<link href="common/css/common.css" rel="stylesheet" type="text/css" />
 		<script class="remove">
 			// <![CDATA[
 			var respecConfig = {
-				postProcess: [create_manifest, convert_dfn_to_link],
+				preProcess: [
+					prepare_reqlist
+				],
+				postProcess: [
+					create_manifest,
+					convert_dfn_to_link,
+					add_reqlist_button
+				],
 				wg: "Publishing Working Group",
 				specStatus: "ED",
 				shortName: "pub-manifest",


### PR DESCRIPTION
### Description/Context

This adds a "List of Requirements" as an additional navigation section, after the table of contents.

I'm intending for this to be a (hopefully) useful tool for reviewing the editor's draft as a part of the ReSpec workflow. I developed this in response to our TPAC F2F, when we talked about extracting the MUSTs/SHOULDs into a spreadsheet, for the creation of test cases.

### Details

The added nav list is populated by scraping the specification document's HTML markup.

Each list item is an occurrence of a "MUST" or "SHOULD" RFC 2119 keyword, along with some context.

List item headers link back to the respective section containing the keyword.

The item elements themselves are clickable, and scroll to the reference location in the document.

A "shortcut" button appears next to the ReSpec UI button, to allow for jumping to the list.
This also has a secondary purpose, as it signals the existence of this feature.

I marked the created elements that are added to the nav with the `removeOnSave` class.
This class makes ReSpec remove the marked elements for when it gets saved. 
Meaning that this list and its content won't show up in the resulting specification document.
The list only shows during the time the document is viewed with ReSpec, and before it's saved.

### Demo

Here's a demo on how this PR looks like when it's running live, with ReSpec in runtime:
https://jccr.github.io/pub-manifest/ 
Try it out with the "ReqList" button, the one next to the "ReSpec" button on the top right.

### Result

If this merges into master, I anticipate that it will be available for everyone to use, when browsing through this repo's GitHub pages site.
I'm referring to the version of the draft that's linked in the readme:
> This is the repository of the W3C’s specification on Publication Manifests, developed by the [Publishing Working Group](https://www.w3.org/publishing/groups/publ-wg/).
>The editors’ draft of the specification can also be __[read directly](https://w3c.github.io/pub-manifest/)__.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jccr/pub-manifest/pull/79.html" title="Last updated on Oct 3, 2019, 6:43 PM UTC (db658b4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/79/41b0957...jccr:db658b4.html" title="Last updated on Oct 3, 2019, 6:43 PM UTC (db658b4)">Diff</a>