### PR TITLE
Update publication.schema.json

### DIFF
--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -14,6 +14,7 @@
                     "const": "https://www.w3.org/ns/pub-context"
                 }
             ],
+            "additionalItems" : true,
             "uniqueItems": true
         },
         "type": {


### PR DESCRIPTION
I believe we have to put `"additionalItems":true`, otherwise the extra objects will not be allowed. We _could_ refine this by sayint somethings like

```
"additionalItems" : {
    "oneOf" : ...
```

for url-s or strings, but I would think we may stop here.

(I am at the airport here, soon to board, so I cannot check/go into details here...)