### PR TITLE
Remove requirement for type

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,9 +293,6 @@
 						<a href="#manifest-context">context</a>
 					</li>
 					<li>
-						<a href="#publication-types">type</a>
-					</li>
-					<li>
 						<a href="#profile-conformance">conformsTo</a>
 					</li>
 				</ul>
@@ -339,7 +336,7 @@
 
 					<pre class="idl" id="wpm">
 dictionary PublicationManifest {
-    required sequence&lt;DOMString>         type;
+             sequence&lt;DOMString>         type = "CreativeWork";
     required sequence&lt;DOMString>         conformsTo;
              DOMString                   id;
              boolean                     abridged;


### PR DESCRIPTION
I noticed that we have `type` listed as a required property, but we also assume a default of "CreativeWork" when it's not specified, which sort of undermines it being required.

This PR removes `type` from the required property list and also specifies the default value in the webidl.

This means that only `@context` and `conformsTo` always have to be specified, which seems right as these are keys to knowing you have a pub manifest and what kind. The other key pieces of metadata either have a default or are harvested when not specified.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/91.html" title="Last updated on Oct 1, 2019, 1:13 PM UTC (2cc4995)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/91/35a23c9...2cc4995.html" title="Last updated on Oct 1, 2019, 1:13 PM UTC (2cc4995)">Diff</a>