### PR TITLE
Fix "ReqList" stylesheet include

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 		<script src="common/js/pub.js" class="remove"></script>
 		<script src="common/js/idllink.js" class="remove"></script>
 		<script src="https://unpkg.com/reqlist/lib/reqlist.js" class="remove"></script>
-		<link href="https://unpkg.com/reqlist/lib/reqlist.css" class="remove" rel="stylesheet" type="text/css" />
+		<link href="https://unpkg.com/reqlist/lib/reqlist.css" class="removeOnSave" rel="stylesheet" type="text/css" />
 		<link href="common/css/common.css" rel="stylesheet" type="text/css" />
 		<script class="remove">
 			// <![CDATA[


### PR DESCRIPTION
I made a mistake with the respec specific classes I used for #79 
The styles for the requirements list are not being applied if the class `remove` is on the reqlist stylesheet include.

This means that the requirements list has unintended numbering, since the stylesheet with the intended styles gets removed right away by ReSpec.

![w3c github io_pub-manifest_](https://user-images.githubusercontent.com/5132652/66283494-90870c80-e878-11e9-9440-9a990c43f598.png)


Changing this to `removeOnSave` applies the intended lifecycle for this link element: Not removing right away, but removing when ReSpec exports or finalizes the TR.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jccr/pub-manifest/pull/99.html" title="Last updated on Oct 7, 2019, 3:35 AM UTC (09b707b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/99/9437d12...jccr:09b707b.html" title="Last updated on Oct 7, 2019, 3:35 AM UTC (09b707b)">Diff</a>