### PR TITLE
Updates to processing algorithm and other fixes

### DIFF
--- a/common/css/common.css
+++ b/common/css/common.css
@@ -91,14 +91,14 @@ summary {
 	font-size: small;
 }
 
-#manifest-processing > ol > li > ol  {
+#manifest-processing ol > li > ol  {
 	list-style-type: lower-alpha;
 }
 
-#manifest-processing > ol > li > ol > li > ol  {
+#manifest-processing ol > li > ol > li > ol  {
 	list-style-type: lower-roman;
 }
 
-#manifest-processing > ol > li > ol > li > ol > li > ol {
+#manifest-processing ol > li > ol > li > ol > li > ol {
 	list-style-type: decimal;
 }

--- a/index.html
+++ b/index.html
@@ -858,7 +858,7 @@
 							href="https://url.spec.whatwg.org/#absolute-url-string">absolute-URL strings</a> using a <a
 							href="https://url.spec.whatwg.org/#concept-base-url">base URL</a>&#160;[[!url]].</p>
 
-					<p id="manifest-base-url">The base URL for relative-URL strings is determined as follows:</p>
+					<p>The <dfn>base URL</dfn> for relative-URL strings is determined as follows:</p>
 
 					<ul>
 						<li>In the case of an <a href="#manifest-embed">embedded manifest</a>, it is the <a
@@ -2839,8 +2839,7 @@
 
 				<ul>
 					<li><var>text</var>: a UTF-8 string representing the manifest;</li>
-					<li><var>base</var>: a URL string that represents the <a href="#manifest-base-url">base URL for the
-							manifest</a>.</li>
+					<li><var>base</var>: a URL string that represents the <a>base URL</a> for the manifest.</li>
 					<li><var>document</var>: the <a data-cite="html#the-document-object">HTML Document (DOM)
 						Node</a>&#160;[[!html]] of the document that <a href="#manifest-discovery">references the
 							manifest</a>, when available.</li>
@@ -2857,12 +2856,6 @@
 						manifest</dfn>, run the following steps:</p>
 
 				<ol>
-					<li id="processing-init">
-						<p>Let <var>processed</var> be an empty <a href="https://infra.spec.whatwg.org/#ordered-map"
-								>map</a> that will contain the <a href="#dfn-internal-representation">internal
-								representation</a> of the manifest.</p>
-					</li>
-
 					<li id="processing-json-infra">
 						<p>Let <var>manifest</var> be the result of parsing <a
 								href="https://infra.spec.whatwg.org/#parse-json-into-infra-values">JSON into Infra
@@ -2948,39 +2941,31 @@
 						</details>
 					</li>
 
+					<li id="processing-create-processed">
+						<p>Let <var>processed</var> be an empty <a href="https://infra.spec.whatwg.org/#ordered-map"
+								>map</a> that will contain the <a href="#dfn-internal-representation">internal
+								representation</a> of the manifest.</p>
+					</li>
+
 					<li id="processing-normalize">
 						<p><a href="https://infra.spec.whatwg.org/#map-iterate">For each</a>
 							<var>term</var> → <var>value</var> of <var>manifest</var>, set <var>processed[term]</var> to
 							the result, when successful, of calling <a>normalize data</a> given <var>term</var>,
-								<var>value</var>, <var>lang</var> and <var>dir</var>. If failure is returned, do not add
-								<var>term</var> to <var>processed</var>.</p>
-					</li>
-
-					<li id="processing-defaults">
-						<p>Set <var>processed</var> to the result of running <a>add HTML defaults</a>, when successful,
-							given <var>processed</var> and <var>document</var>. If failure is returned, terminate
-							processing, return failure.</p>
+								<var>value</var>, <var>lang</var>, <var>dir</var> and <var>base</var>. If failure is
+							returned, do not add <var>term</var> to <var>processed</var>.</p>
 					</li>
 
 					<li id="processing-checks">
 						<p>Set <var>processed</var> to the result of running <a>data validation</a> given
 								<var>processed</var>.</p>
 					</li>
-
-					<li id="processing-remove-empty-arrays">
-						<p><a href="https://infra.spec.whatwg.org/#map-iterate">For each</a>
-							<var>term</var> → <var>value</var> of <var>processed</var>, if running <a>remove empty
-								arrays</a> given the variables <var>term</var> and <var>value</var> returns failure, <a
-								href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-							<var>processed["term"]</var>.</p>
-						<details>
-							<summary>Explanation</summary>
-							<p>As the processing of the manifest involves removing invalid values at various stages, the
-								final data structure might end up with some lists that not no longer contain any values.
-								This step iterates back over the data and removes any such empty lists.</p>
-						</details>
+					
+					<li id="processing-defaults">
+						<p>Set <var>processed</var> to the result of running <a>add HTML defaults</a>, when successful,
+							given <var>processed</var> and <var>document</var>. Otherwise, terminate processing, return
+							failure.</p>
 					</li>
-
+					
 					<li id="processing-end">
 						<p>Return <var>processed</var>.</p>
 					</li>
@@ -2996,9 +2981,11 @@
 						the direct property of the Publication Manifest, but a single URL literal when used in other
 						objects.</p>
 
-					<p>To <dfn>normalize data</dfn> for a property <var>term</var>'s <var>value</var>, with optional <a
-							href="https://infra.spec.whatwg.org/#string">strings</a>
-						<var>language</var> and <var>direction</var>, run these steps:</p>
+					<p>To <dfn>normalize data</dfn> for a property <var>term</var>'s <var>value</var>, with the <a
+							href="#manifest-lang-dir-global">global language</a>
+						<var>lang</var>, <a href="#manifest-lang-dir-global">global direction</a>
+						<var>dir</var> and <a>base URL</a>
+						<var>base</var>, run these steps:</p>
 
 					<ol>
 						<li id="normalize-init">
@@ -3009,7 +2996,7 @@
 							<p>(<a href="#value-array"></a>) If <var>term</var> expects an <a href="#value-array"
 									>array</a> and <var>value</var> is a <a href="https://infra.spec.whatwg.org/#string"
 									>string</a>, <a href="https://infra.spec.whatwg.org/#boolean">boolean</a>, number,
-								or <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>, set
+								null, or <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>, set
 									<var>normalized</var> to «&#160;<var>value</var>&#160;».</p>
 							<details>
 								<summary>Explanation</summary>
@@ -3084,8 +3071,8 @@
 
 						<li id="normalize-localizable-strings">
 							<p>(<a href="#value-localizable-string"></a>) If <var>term</var> expects an <a
-									href="#value-array">array</a> of localizable strings, <a
-									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+									href="#value-array">array</a> of <a href="#value-localizable-string">localizable
+									strings</a>, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
 								<var>item</var> of <var>normalized</var>:</p>
 							<ol>
 								<li id="ls-value-normalize">
@@ -3094,19 +3081,20 @@
 											href="https://infra.spec.whatwg.org/#ordered-map">map</a>:</p>
 									<pre>«[
     "value" → <var>value</var>,
-    "language" → <var>language</var>,
-    "direction" → <var>direction</var>
+    "language" → <var>lang</var>,
+    "direction" → <var>dir</var>
 ]»</pre>
-									<p>if <var>language</var> or <var>direction</var> is not set, or is an empty <a
+									<p>if <var>lang</var> or <var>dir</var> is not set, or is an empty <a
 											href="https://infra.spec.whatwg.org/#string">strings</a>, <a
 											href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 										<var>item["language"]</var> or <var>item["direction"]</var>, respectively.</p>
 								</li>
 								<li id="ls-error">
-									<p>otherwise, if <var>item</var> is number, <a
-											href="https://infra.spec.whatwg.org/#boolean">boolean</a> or <a
-											href="https://infra.spec.whatwg.org/#nulls">null</a>, <a>validation
-											error</a>, remove <var>item</var> from <var>normalized</var>.</p>
+									<p>otherwise, if <var>item</var> is a <a href="https://infra.spec.whatwg.org/#list"
+											>list</a>, number, <a href="https://infra.spec.whatwg.org/#boolean"
+											>boolean</a> or <a href="https://infra.spec.whatwg.org/#nulls">null</a>,
+											<a>validation error</a>, remove <var>item</var> from
+										<var>normalized</var>.</p>
 								</li>
 								<li id="ls-map-normalize">
 									<p>otherwise, if <var>item</var> is a <a
@@ -3114,17 +3102,17 @@
 									<ol>
 										<li>
 											<p>if <var>item["language"]</var> is not set, set it to the value of
-													<var>language</var> when <var>language</var> is set and is not an
-												empty <a href="https://infra.spec.whatwg.org/#string">string</a>.</p>
-											<p>otherwise, <var>item["language"]</var> is <a
+													<var>lang</var> when <var>lang</var> is set and is not an empty <a
+													href="https://infra.spec.whatwg.org/#string">string</a>.</p>
+											<p>otherwise, if <var>item["language"]</var> is <a
 													href="https://infra.spec.whatwg.org/#nulls">null</a>, <a
 													href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 												<var>item["language"]</var>.</p>
 										</li>
 										<li>
 											<p>if <var>item["direction"]</var> is not set, set it to the value of
-													<var>direction</var> when <var>direction</var> is set and is not an
-												empty <a href="https://infra.spec.whatwg.org/#string">string</a>.</p>
+													<var>dir</var> when <var>dir</var> is set and is not an empty <a
+													href="https://infra.spec.whatwg.org/#string">string</a>.</p>
 											<p>otherwise, if <var>item["direction"]</var> is <a
 													href="https://infra.spec.whatwg.org/#nulls">null</a>, <a
 													href="https://infra.spec.whatwg.org/#map-remove">remove</a>
@@ -3240,7 +3228,8 @@
 ]»</pre>
 								</li>
 								<li>
-									<p>otherwise, if <var>resource</var> is number, <a
+									<p>otherwise, if <var>resource</var> is a <a
+											href="https://infra.spec.whatwg.org/#list">list</a>, number, <a
 											href="https://infra.spec.whatwg.org/#boolean">boolean</a> or <a
 											href="https://infra.spec.whatwg.org/#nulls">null</a>, <a>validation
 											error</a>, remove <var>resource</var> from <var>normalized</var>.</p>
@@ -3278,22 +3267,10 @@
 						</li>
 
 						<li id="normalize-urls">
-							<p>(<a href="#value-url"></a>) If <var>term</var> expects a <a href="#value-url">URL</a></p>
-							<ol>
-								<li>
-									<p>if <var>normalized</var> is a <a href="https://infra.spec.whatwg.org/#string"
-											>string</a>, set <var>normalized</var> to the result of running the <a
-											href="https://url.spec.whatwg.org/#concept-url-parser">URL parser</a> with
-											<var>normalized</var> as input and <var>base</var> as the base URL.</p>
-								</li>
-								<li>
-									<p>otherwise, if <var>normalized</var> is a number, <a
-											href="https://infra.spec.whatwg.org/#boolean">boolean</a> or <a
-											href="https://infra.spec.whatwg.org/#nulls">null</a>, <a>validation
-											error</a>, then <a href="https://infra.spec.whatwg.org/#iteration-continue"
-											>continue</a>.</p>
-								</li>
-							</ol>
+							<p>(<a href="#value-url"></a>) If <var>term</var> expects a <a href="#value-url">URL</a> or
+									<a href="#value-array">array</a> of URLs, set <var>normalized</var> to the result of
+								running <a>absolute URL check</a>, when successful, given <var>normalized</var>.
+								Otherwise, return failure.</p>
 							<details>
 								<summary>Explanation</summary>
 								<p>All relative URLs in the publication manifest must be resolved against the base value
@@ -3313,16 +3290,18 @@
 									href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
 									href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
 								<var>key</var> → <var>keyValue</var> of <var>normalized</var>, set <var>key</var> to the
-								result of running <a href="#processing-normalize">this step</a> on
-								<var>keyValue</var>.</p>
+								result of running <a href="#processing-normalize">normalize data</a> given
+									<var>key</var>, <var>keyValue</var>, <var>lang</var>, <var>dir</var> and
+									<var>base</var>.</p>
 						</li>
 
 						<li id="normalize-recurse-maps">
 							<p>if <var>normalized</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
 									>map</a>, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
 								<var>key</var> → <var>keyValue</var> of <var>normalized</var>, set <var>key</var> to the
-								result of running <a href="#processing-normalize">this step</a> on
-								<var>keyValue</var>.</p>
+								result of running <a href="#processing-normalize">normalize data</a> given
+									<var>key</var>, <var>keyValue</var>, <var>lang</var>, <var>dir</var> and
+									<var>base</var>.</p>
 						</li>
 
 						<li id="normalize-end">
@@ -3332,107 +3311,31 @@
 
 				</section>
 
-				<section id="add-html-defaults">
-					<h3>Add HTML Default Values</h3>
+				<section id="absolute-url-check">
+					<h4>Absolute URL Check</h4>
 
-					<p>To <dfn>add HTML defaults</dfn> for missing properties in <a
-							href="https://infra.spec.whatwg.org/#ordered-map">map</a>
-						<var>data</var> with a HTML document node <var>document</var>, run the following steps:</p>
+					<p>To perform an <dfn>absolute URL check</dfn> on <var>data</var>, with a base URL <var>base</var>,
+						run the following steps:</p>
 
 					<ol>
-						<li id="processing-defaults-title">
-							<p>(<a href="#pub-title"></a>) If <var>data["name"]</var> is not set, or its value is an
-								empty <a href="https://infra.spec.whatwg.org/#string">string</a>:</p>
-							<ul>
-								<li>
-									<p>Let <var>title</var> be an empty <a
-											href="https://infra.spec.whatwg.org/#ordered-map">map</a>. Set its values as
-										follows:</p>
-									<ul>
-										<li>
-											<p>if the <a data-cite="html#the-title-element"><code>title</code></a>
-												element&#160;[[!html]] of <var>document</var> is set and its contains is
-												not empty, set <var>title["value"]</var> to the text content of the
-													<code>title</code> element.</p>
-											<p>Set <var>title["language"]</var> to the <a
-													data-cite="html#the-lang-and-xml:lang-attributes"
-												>language</a>&#160;[[!html]], if available, and
-													<var>title["direction"]</var> to the <a
-													data-cite="html#the-dir-attribute">base direction</a>&#160;[[!html]]
-												if that value is available and its value is either "<code>ltr</code>" or
-													"<code>rtl</code>". </p>
-										</li>
-										<li>
-											<p>otherwise, <a>validation error</a>, generate a value for
-													<var>title["value"]</var> (see the <a href="#generate_title"
-													>separate note for details</a>). Set <var>title["language"]</var>
-												and <var>title["direction"]</var> as approrpriate for the generated
-												title.</p>
-										</li>
-									</ul>
-								</li>
-								<li>Set <var>data["name"]</var> to <code>«&#160;<var>title</var>&#160;»</code>.</li>
-							</ul>
-							<details>
-								<summary>Explanation</summary>
-								<p>This step adds the content of the <code>title</code> element of <var>document</var>
-									when the <code>name</code> property is not specified in the manifest. For
-									example:</p>
-								<pre class="example">&lt;html&gt;
-&lt;head lang="en"&gt;
-    &lt;title&gt;The Golden Bough&lt;/title&gt;
-    …
-    &lt;script type="application/ld+json"&gt;
-    {
-        "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-        …
-    }
-    &lt;/script&gt;</pre>
-								<p>yields:</p>
-								<pre class="example">{
-    …
-    "name" : [
-        {
-            "value" : "The Golden Bough",
-            "language" : "en"
-        }
-    ],
-    …
-}</pre>
-							</details>
+						<li>
+							<p>if <var>data</var> is a <a href="https://infra.spec.whatwg.org/#string">string</a>, set
+									<var>data</var> to the result of running the <a
+									href="https://url.spec.whatwg.org/#concept-url-parser">URL parser</a> with
+									<var>data</var> as input and <var>base</var> as the base URL.</p>
 						</li>
-
-						<li id="processing-defaults-reading-order">
-							<p>(<a href="#default-reading-order"></a>) If <var>data["readingOrder"]</var> is not set or
-								its value is an empty <a href="https://infra.spec.whatwg.org/#string">string</a> or <a
-									href="https://infra.spec.whatwg.org/#list">list</a>:</p>
-							<ul>
-								<li>
-									<p>if <a data-cite="!dom#concept-document-url">document.URL</a> is not set, this is
-										a <a>fatal error</a>. Return failure.</p>
-								</li>
-								<li>
-									<p>otherwise, set <var>data["readingOrder"]</var> to an empty <a
-											href="https://infra.spec.whatwg.org/#list">list</a> and <a
-											href="https://infra.spec.whatwg.org/#list-append">append</a> the <a
-											href="https://infra.spec.whatwg.org/#ordered-map">map</a>
-										<code>«[&#160;"url" → <a data-cite="!dom#concept-document-url"
-											>document.URL</a>&#160;]»</code>.</p>
-								</li>
-							</ul>
-							<details>
-								<summary>Explanation</summary>
-								<p> If the Digital Publication consists only of the referencing document, the default
-									reading order can be omitted; it will consist, automatically, of that single
-									resource. </p>
-							</details>
+						<li>
+							<p>otherwise, if <var>data</var> is a <a href="https://infra.spec.whatwg.org/#list"
+								>list</a>, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+								<var>item</var> of <var>data</var>, set <var>item</var> to the result of runing
+									<a>absolute URL check</a>, when successful, given <var>item</var> and
+									<var>base</var>. Otherwise, <a href="https://infra.spec.whatwg.org/#list-remove"
+									>remove</a>
+								<var>item</var> from <var>data</var>.</p>
 						</li>
-
-						<li id="processing-defaults-extension">
-							<p>If a <a>profile</a> specifies <var>document</var> fallbacks, those steps are executed at
-								this point.</p>
+						<li>
+							<p>otherwise, <a>validation error</a>, return failure.</p>
 						</li>
-
 						<li>
 							<p>Return <var>data</var>.</p>
 						</li>
@@ -3460,12 +3363,13 @@
 								to <code>«&#160;"CreativeWork"&#160;»</code>.</p>
 						</li>
 
+						<!-- handled by category check
 						<li id="validate-abridged">
 							<p>(<a href="#abridged"></a>) If <var>data["abridged"]</var> is set and is not a <a
 									href="https://infra.spec.whatwg.org/#boolean">boolean</a>, <a>validation error</a>,
 									<a href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 								<var>data["abridged"]</var>.</p>
-						</li>
+						</li>-->
 
 						<li id="validate-ams">
 							<p>(<a href="#accessibility"></a>) If <var>data["accessModeSufficient"]</var> is set, <a
@@ -3517,7 +3421,21 @@
 							<p>If a <a>profile</a> specifies data validation checks, those steps are executed at this
 								point.</p>
 						</li>
-
+						
+						<li id="processing-remove-empty-arrays">
+							<p><a href="https://infra.spec.whatwg.org/#map-iterate">For each</a>
+								<var>term</var> → <var>value</var> of <var>data</var>, if running <a>remove empty
+									arrays</a> given the variables <var>term</var> and <var>value</var> returns failure, <a
+										href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+								<var>data["term"]</var>.</p>
+							<details>
+								<summary>Explanation</summary>
+								<p>As the processing of the manifest involves removing invalid values at various stages, the
+									final data structure might end up with some lists that not no longer contain any values.
+									This step iterates back over the data and removes any such empty lists.</p>
+							</details>
+						</li>
+						
 						<li id="validate-end">
 							<p>Return <var>data</var>.</p>
 						</li>
@@ -3534,8 +3452,8 @@
 						<li id="common-checks-value-categories">
 							<p>(<a href="#properties-value-categories"></a>) If <var>term</var> has a known <a
 									href="#properties-value-categories">value category</a>, set <var>value</var> to the
-								result of calling <a href="#category-check">value category check</a> given the variables
-									<var>term</var> and <var>value</var>.</p>
+								result of calling <a href="#category-check">value category check</a>, when successful,
+								given the variables <var>term</var> and <var>value</var>. Otherwise, return failure.</p>
 						</li>
 						<li id="common-checks-entities">
 							<p>(<a href="#value-entity"></a>) If <var>term</var> expects an <a href="#value-array"
@@ -3577,7 +3495,7 @@
 
 						<li id="common-checks-linkedresource">
 							<p>(<a href="#value-linked-resource"></a>) If <var>term</var> expects an <a
-									href="#value-array">array</a> of <a href="#LinkedResource-def">LinkedResource</a>,
+									href="#value-array">array</a> of <a href="#LinkedResource-def">LinkedResources</a>,
 									<a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
 								<var>resource</var> of <var>value</var>:</p>
 							<ul>
@@ -3585,11 +3503,13 @@
 									<p>if <var>resource["url"]</var> is not set, or its value is an empty string,
 											<a>validation error</a>, <a
 											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-										<var>item</var> from <var>value</var>.</p>
+										<var>resource</var> from <var>value</var>, then <a
+											href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
 									<p>Otherwise, if <var>resource["url"]</var> is not a valid URL&#160;[[!url]],
 											<a>validation error</a>, <a
 											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-										<var>item</var> from <var>value</var>.</p>
+										<var>resource</var> from <var>value</var>, then <a
+											href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
 								</li>
 								<li>
 									<p>if <a href="#linkedresource-length"><var>resource["length"]</var></a> is set and
@@ -3654,7 +3574,9 @@
 											<p>if <var>item</var> does not match the expected type of the array,
 													<a>validation error</a>, <a
 													href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-												<var>item</var> from <var>value</var>.</p>
+												<var>item</var> from <var>value</var>, then <a
+													href="https://infra.spec.whatwg.org/#iteration-continue"
+													>continue</a>.</p>
 										</li>
 										<li>
 											<p>if <var>item</var> is a <a
@@ -3723,6 +3645,113 @@
 									arrays</a> given <var>key</var> and <var>keyValue</var> returns failure, <a
 									href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 								<var>value[key]</var>.</p>
+						</li>
+					</ol>
+				</section>
+				
+				<section id="add-html-defaults">
+					<h3>Add HTML Default Values</h3>
+					
+					<p>To <dfn>add HTML defaults</dfn> for missing properties in <a
+						href="https://infra.spec.whatwg.org/#ordered-map">map</a>
+						<var>data</var> with a HTML document node <var>document</var>, run the following steps:</p>
+					
+					<ol>
+						<li id="processing-defaults-title">
+							<p>(<a href="#pub-title"></a>) If <var>data["name"]</var> is not set, or its value is an
+								empty <a href="https://infra.spec.whatwg.org/#string">string</a>:</p>
+							<ul>
+								<li>
+									<p>Let <var>title</var> be an empty <a
+										href="https://infra.spec.whatwg.org/#ordered-map">map</a>. Set its values as
+										follows:</p>
+									<ul>
+										<li>
+											<p>if the <a data-cite="html#the-title-element"><code>title</code></a>
+												element&#160;[[!html]] of <var>document</var> is set and its contains is
+												not empty, set <var>title["value"]</var> to the text content of the
+												<code>title</code> element.</p>
+											<p>Set <var>title["language"]</var> to the <a
+												data-cite="html#the-lang-and-xml:lang-attributes"
+												>language</a>&#160;[[!html]], if available, and
+												<var>title["direction"]</var> to the <a
+													data-cite="html#the-dir-attribute">base direction</a>&#160;[[!html]]
+												if that value is available and its value is either "<code>ltr</code>" or
+												"<code>rtl</code>". </p>
+										</li>
+										<li>
+											<p>otherwise, <a>validation error</a>, generate a value for
+												<var>title["value"]</var> (see the <a href="#generate_title"
+													>separate note for details</a>). Set <var>title["language"]</var>
+												and <var>title["direction"]</var> as approrpriate for the generated
+												title.</p>
+										</li>
+									</ul>
+								</li>
+								<li>Set <var>data["name"]</var> to <code>«&#160;<var>title</var>&#160;»</code>.</li>
+							</ul>
+							<details>
+								<summary>Explanation</summary>
+								<p>This step adds the content of the <code>title</code> element of <var>document</var>
+									when the <code>name</code> property is not specified in the manifest. For
+									example:</p>
+								<pre class="example">&lt;html&gt;
+&lt;head lang="en"&gt;
+    &lt;title&gt;The Golden Bough&lt;/title&gt;
+    …
+    &lt;script type="application/ld+json"&gt;
+    {
+        "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+        …
+    }
+    &lt;/script&gt;</pre>
+								<p>yields:</p>
+								<pre class="example">{
+    …
+    "name" : [
+        {
+            "value" : "The Golden Bough",
+            "language" : "en"
+        }
+    ],
+    …
+}</pre>
+							</details>
+						</li>
+						
+						<li id="processing-defaults-reading-order">
+							<p>(<a href="#default-reading-order"></a>) If <var>data["readingOrder"]</var> is not set or
+								its value is an empty <a href="https://infra.spec.whatwg.org/#string">string</a> or <a
+									href="https://infra.spec.whatwg.org/#list">list</a>:</p>
+							<ul>
+								<li>
+									<p>if <a data-cite="!dom#concept-document-url">document.URL</a> is not set, this is
+										a <a>fatal error</a>. Return failure.</p>
+								</li>
+								<li>
+									<p>otherwise, set <var>data["readingOrder"]</var> to an empty <a
+										href="https://infra.spec.whatwg.org/#list">list</a> and <a
+											href="https://infra.spec.whatwg.org/#list-append">append</a> the <a
+												href="https://infra.spec.whatwg.org/#ordered-map">map</a>
+										<code>«[&#160;"url" → <a data-cite="!dom#concept-document-url"
+											>document.URL</a>&#160;]»</code>.</p>
+								</li>
+							</ul>
+							<details>
+								<summary>Explanation</summary>
+								<p> If the Digital Publication consists only of the referencing document, the default
+									reading order can be omitted; it will consist, automatically, of that single
+									resource. </p>
+							</details>
+						</li>
+						
+						<li id="processing-defaults-extension">
+							<p>If a <a>profile</a> specifies <var>document</var> fallbacks, those steps are executed at
+								this point.</p>
+						</li>
+						
+						<li>
+							<p>Return <var>data</var>.</p>
 						</li>
 					</ol>
 				</section>
@@ -3814,7 +3843,7 @@
 					<pre id="wpm">
 dictionary PublicationManifest {
              sequence&lt;DOMString>         type = "CreativeWork";
-             sequence&lt;DOMString>         conformsTo = "https://www.w3.org/TR/pub-manifest";
+    required sequence&lt;DOMString>         conformsTo;
              DOMString                   id;
              boolean                     abridged;
              sequence&lt;DOMString>         accessMode;

--- a/index.html
+++ b/index.html
@@ -199,7 +199,7 @@
 						<dd>
 							<p>Descriptive properties describe aspects of a digital publication, such as its <a
 									href="#pub-title">title</a>, <a href="#creators">creator</a>, and <a
-									href="#language-and-dir">language</a>.</p>
+									href="inLanguage">language</a>.</p>
 						</dd>
 						<dt>
 							<a href="#resource-categorization-properties">Resource categorization properties</a>
@@ -259,10 +259,10 @@
 
 					<p>The publication manifest also has a number of authoring flexibilities and compact authoring
 						expressions. For example, it is not always required that object types be explicitly authored, as
-						these are automatically generated during processing when missing (see <a href="#value-objects"
-						></a> for more information). An <a>internal representation</a> of the manifest data is defined
-						separately; see the separate section on <a href="#internal-rep-data-model"></a> for further
-						details.</p>
+						these are automatically generated during processing when missing (see <a
+							href="#explicit-implied-objects"></a> for more information). An <a>internal
+							representation</a> of the manifest data is defined separately; see the separate section on
+							<a href="#internal-rep-data-model"></a> for further details.</p>
 
 					<p>As a consequence, a user agent does not have to be a full JSON-LD processor. User agents only
 						need to be able to read the manifest's specific shape and internalize the data.</p>
@@ -335,8 +335,8 @@
 							>string</a>.</p>
 
 					<p>Literal values are not changed <a href="#manifest-processing">during processing of the
-							manifest</a>, unlike other values which might be, for example, <a href="#value-objects"
-							>converted to objects</a>.</p>
+							manifest</a>, unlike other values which might be, for example, <a
+							href="#explicit-implied-objects">converted to objects</a>.</p>
 				</section>
 
 				<section id="value-number">
@@ -356,7 +356,7 @@
 							(<code>true</code> or <code>false</code>).</p>
 				</section>
 
-				<section id="value-objects">
+				<section id="explicit-implied-objects">
 					<h4>Explicit and Implied Objects</h4>
 
 					<p>Various manifest properties are expected to be expressed as [[!json]]&#160;<a
@@ -390,14 +390,14 @@
 									<th>Term</th>
 									<th>Description</th>
 									<th>Required Value</th>
-									<th>Value Type</th>
+									<th>Value Category</th>
 									<th>[[!schema.org]] Mapping</th>
 								</tr>
 							</thead>
 							<tbody>
 								<tr>
 									<td>
-										<code> value </code>
+										<code>value</code>
 									</td>
 									<td>The value of the localizable string. REQUIRED.</td>
 									<td>Text.</td>
@@ -406,7 +406,7 @@
 								</tr>
 								<tr>
 									<td>
-										<code> language </code>
+										<code>language</code>
 									</td>
 									<td>The language of the value. OPTIONAL.</td>
 									<td>A <a href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
@@ -416,7 +416,7 @@
 								</tr>
 								<tr>
 									<td>
-										<code> direction </code>
+										<code>direction</code>
 									</td>
 									<td>The base direction of the value. OPTIONAL.</td>
 									<td><code>ltr</code> or <code>rtl</code></td>
@@ -494,7 +494,7 @@
 									<th>Term</th>
 									<th>Description</th>
 									<th>Required Value</th>
-									<th>Value Type</th>
+									<th>Value Category</th>
 									<th>[[!schema.org]] Mapping</th>
 								</tr>
 							</thead>
@@ -558,7 +558,7 @@
 										<code>identifier</code>
 									</td>
 									<td>An identifier associated with the creator (e.g., ORCID). OPTIONAL.</td>
-									<td>One or more text(s).</td>
+									<td>One or more Text.</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
 									</td>
@@ -618,7 +618,7 @@
 									<th>Term</th>
 									<th>Description</th>
 									<th>Required Value</th>
-									<th>Value Type</th>
+									<th>Value Category</th>
 									<th>[[!schema.org]] Mapping</th>
 								</tr>
 							</thead>
@@ -670,7 +670,7 @@
 										<code>name</code>
 									</td>
 									<td>Name of the item. OPTIONAL.</td>
-									<td>One or more Text items.</td>
+									<td>One or more Text.</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-localizable-string"
 											>Localizable Strings</a>
@@ -686,9 +686,10 @@
 										<code>description</code>
 									</td>
 									<td>Description of the item. OPTIONAL.</td>
-									<td>Text.</td>
+									<td>One or more Text.</td>
 									<td>
-										<a href="#value-localizable-string">Localizable String</a>
+										<a href="#value-array">Array</a> of <a href="#value-localizable-string"
+											>Localizable Strings</a>
 									</td>
 									<td>
 										<a href="https://schema.org/description">
@@ -698,7 +699,7 @@
 								</tr>
 								<tr>
 									<td id="linkedresource-rel">
-										<code> rel </code>
+										<code>rel</code>
 									</td>
 									<td>The relation of the resource to the publication. OPTIONAL.</td>
 									<td>
@@ -762,8 +763,8 @@
 												an alternative format; or</li>
 											<li>an instance of a <code>LinkedResource</code> object</li>
 										</ul>
-										<p>The order of items is <em>not significant</em>. Non-HTML resources SHOULD be
-											expressed as <code>LinkedResource</code> objects with their
+										<p>The order of items is <em>not significant</em>. Resources SHOULD be expressed
+											as <code>LinkedResource</code> objects with their
 												<code>encodingFormat</code> values set.</p>
 									</td>
 									<td>
@@ -830,6 +831,15 @@
     …
 }</pre>
 					</section>
+
+					<section id="value-object">
+						<h3>Objects</h3>
+
+						<p>When a manifest property expects a type of object not defined in this section, or by a
+								<a>profile</a>, it MUST be expressed as a [[!json]] <a
+								href="https://tools.ietf.org/html/rfc4627#section-2.2">object</a> (i.e., the property's
+							value will not be processed to create an object).</p>
+					</section>
 				</section>
 
 				<section id="value-url">
@@ -889,8 +899,8 @@
 					<h4>Arrays</h4>
 
 					<p>When a <a href="#manifest-properties">manifest property</a> allows one or more value of their
-						respective type (e.g., <a href="#value-literal">literal</a>, <a href="#value-objects"
-						>object</a>, or <a href="#value-url">URL</a>), these values are expressed as [[!json]] <a
+						respective type (e.g., <a href="#value-literal">literal</a>, <a href="#explicit-implied-objects"
+							>object</a>, or <a href="#value-url">URL</a>), these values are expressed as [[!json]] <a
 							href="https://tools.ietf.org/html/rfc4627#section-2.3">arrays</a>. When a property value is
 						a single element, however, the array syntax MAY be omitted.</p>
 
@@ -1124,8 +1134,8 @@
 				<p>A <a>digital publication's</a>
 					<a>manifest</a> defines its <dfn>Publication Type</dfn> using the <code>type</code>
 					keyword&#160;[[!json-ld11]]. The type MAY be mapped onto any [[!schema.org]] type, but <a
-						href="https://schema.org/CreativeWork"><code>CreativeWork</code></a> is <a
-						href="#processing-checks-type">assumed as the default</a> when no type is specified.</p>
+						href="https://schema.org/CreativeWork"><code>CreativeWork</code></a> is <a href="#validate-type"
+						>assumed as the default</a> when no type is specified.</p>
 
 				<pre class="example" title="Setting a publication's type to CreativeWork.">{
     "@context" : ["https://schema.org", "https://www.w3.org/ns/pub-context"],
@@ -1178,7 +1188,7 @@
 							<th>Term</th>
 							<th>Description</th>
 							<th>Required Value</th>
-							<th>Value Type</th>
+							<th>Value Category</th>
 							<th>[[!dcterms]] Mapping</th>
 						</tr>
 					</thead>
@@ -1228,14 +1238,14 @@
 									<th>Term</th>
 									<th>Description</th>
 									<th>Required Value</th>
-									<th>Value Type</th>
+									<th>Value Category</th>
 									<th>[[!schema.org]] Mapping</th>
 								</tr>
 							</thead>
 							<tbody>
 								<tr>
 									<td>
-										<code> abridged </code>
+										<code>abridged</code>
 									</td>
 									<td>Indicates whether the book is an abridged edition.</td>
 									<td>Either <code>true</code> or <code>false</code>.</td>
@@ -1276,12 +1286,12 @@
 							</thead>
 							<tbody>
 								<tr>
-									<td>
-										<code> accessMode </code>
+									<td id="accessMode">
+										<code>accessMode</code>
 									</td>
 									<td>The human sensory perceptual system or cognitive faculty through which a person
 										may process or perceive information. </td>
-									<td>One or more text(s).</td>
+									<td>One or more Text.</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
 									</td>
@@ -1290,14 +1300,14 @@
 											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> accessModeSufficient </code>
+									<td id="accessModeSufficient">
+										<code>accessModeSufficient</code>
 									</td>
 									<td> A list of single or combined access modes that are sufficient to understand all
 										the intellectual content of a resource. </td>
 									<td> One or more <a href="https://schema.org/ItemList">ItemList</a>.</td>
 									<td>
-										<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
+										<a href="#value-array">Array</a> of <a href="#value-object">Object</a>
 									</td>
 									<td>
 										<a href="https://schema.org/accessModeSufficient"
@@ -1305,12 +1315,12 @@
 											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> accessibilityFeature </code>
+									<td id="accessibilityFeature">
+										<code>accessibilityFeature</code>
 									</td>
 									<td> Content features of the resource, such as accessible media, alternatives and
 										supported enhancements for accessibility. </td>
-									<td> One or more text(s).</td>
+									<td> One or more Text.</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
 									</td>
@@ -1320,12 +1330,12 @@
 											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> accessibilityHazard </code>
+									<td id="accessibilityHazard">
+										<code>accessibilityHazard</code>
 									</td>
 									<td> A characteristic of the described resource that is physiologically dangerous to
 										some users. </td>
-									<td> One or more text(s).</td>
+									<td> One or more Text.</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-literal">Literals</a>
 									</td>
@@ -1335,14 +1345,15 @@
 											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> accessibilitySummary </code>
+									<td id="accessibilitySummary">
+										<code>accessibilitySummary</code>
 									</td>
 									<td>A human-readable summary of specific accessibility features or deficiencies that
 										is consistent with the other accessibility metadata. </td>
 									<td>Text.</td>
 									<td>
-										<a href="#value-localizable-string">Localizable String</a>
+										<a href="#value-array">Array</a> of <a href="#value-localizable-string"
+											>Localizable Strings</a>
 									</td>
 									<td>
 										<a href="https://schema.org/accessibilitySummary"
@@ -1390,14 +1401,14 @@
 									<th>Term</th>
 									<th>Description</th>
 									<th>Required Value</th>
-									<th>Value Type</th>
+									<th>Value Category</th>
 									<th>[[!schema.org]] Mapping</th>
 								</tr>
 							</thead>
 							<tbody>
 								<tr>
 									<td>
-										<code> url </code>
+										<code>url</code>
 									</td>
 									<td>URL of the publication.</td>
 									<td>A valid URL string&#160;[[!url]].</td>
@@ -1435,14 +1446,14 @@
 									<th>Term</th>
 									<th>Description</th>
 									<th>Required Value</th>
-									<th>Value Type</th>
+									<th>Value Category</th>
 									<th>[[!schema.org]] Mapping</th>
 								</tr>
 							</thead>
 							<tbody>
 								<tr>
 									<td>
-										<code> id </code>
+										<code>id</code>
 									</td>
 									<td>Preferred version of the publication.</td>
 									<td>A URL record&#160;[[!url]].</td>
@@ -1499,8 +1510,8 @@
 							</thead>
 							<tbody>
 								<tr>
-									<td>
-										<code> artist </code>
+									<td id="artist">
+										<code>artist</code>
 									</td>
 									<td>The primary artist for the publication, in a medium other than pencils or
 										digital line art.</td>
@@ -1513,8 +1524,8 @@
 											href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> author </code>
+									<td id="author">
+										<code>author</code>
 									</td>
 									<td>The author of the publication.</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
@@ -1528,8 +1539,8 @@
 											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> colorist </code>
+									<td id="colorist">
+										<code>colorist</code>
 									</td>
 									<td>The individual who adds color to inked drawings.</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
@@ -1541,8 +1552,8 @@
 											href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> contributor </code>
+									<td id="contributor">
+										<code>contributor</code>
 									</td>
 									<td>Contributor whose role does not fit to one of the other roles in this
 										table.</td>
@@ -1557,8 +1568,8 @@
 											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> creator </code>
+									<td id="creator">
+										<code>creator</code>
 									</td>
 									<td>The creator of the publication.</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
@@ -1572,8 +1583,8 @@
 											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> editor </code>
+									<td id="editor">
+										<code>editor</code>
 									</td>
 									<td>The editor of the publication.</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
@@ -1585,8 +1596,8 @@
 											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> illustrator </code>
+									<td id="illustrator">
+										<code>illustrator</code>
 									</td>
 									<td>The illustrator of the publication.</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
@@ -1598,8 +1609,8 @@
 											href="https://schema.org/Book">Book</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> inker </code>
+									<td id="inker">
+										<code>inker</code>
 									</td>
 									<td>The individual who traces over the pencil drawings in ink.</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
@@ -1611,8 +1622,8 @@
 											href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> letterer </code>
+									<td id="letterer">
+										<code>letterer</code>
 									</td>
 									<td>The individual who adds lettering, including speech balloons and sound effects,
 										to artwork.</td>
@@ -1625,8 +1636,8 @@
 											href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> penciler </code>
+									<td id="penciler">
+										<code>penciler</code>
 									</td>
 									<td>The individual who draws the primary narrative artwork.</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>.</td>
@@ -1638,8 +1649,8 @@
 											href="https://schema.org/VisualArtwork">VisualArtwork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> publisher </code>
+									<td id="publisher">
+										<code>publisher</code>
 									</td>
 									<td>The publisher of the publication.</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
@@ -1653,8 +1664,8 @@
 											href="https://schema.org/CreativeWork">CreativeWork</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> readBy </code>
+									<td id="readBy">
+										<code>readBy</code>
 									</td>
 									<td>A person who reads (performs) the publication (for audiobooks).</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a>. </td>
@@ -1666,8 +1677,8 @@
 											href="https://bib.schema.org/Audiobook">Audiobook</a>) </td>
 								</tr>
 								<tr>
-									<td>
-										<code> translator </code>
+									<td id="translator">
+										<code>translator</code>
 									</td>
 									<td>The translator of the publication.</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
@@ -1764,7 +1775,7 @@
 							<tbody>
 								<tr>
 									<td>
-										<code> duration </code>
+										<code>duration</code>
 									</td>
 									<td>Overall duration of a time-based publication.</td>
 									<td>Duration value as defined by&#160;[[!iso8601]].</td>
@@ -1813,7 +1824,7 @@
 							<tbody>
 								<tr>
 									<td>
-										<code> dateModified </code>
+										<code>dateModified</code>
 									</td>
 									<td>Last modification date of the publication.</td>
 									<td>A <a href="https://schema.org/Date"><code>Date</code></a> or <a
@@ -1862,7 +1873,7 @@
 							<tbody>
 								<tr>
 									<td>
-										<code> datePublished </code>
+										<code>datePublished</code>
 									</td>
 									<td>Creation date of the publication.</td>
 									<td>A <a href="https://schema.org/Date"><code>Date</code></a> or <a
@@ -1890,7 +1901,7 @@
 }</pre>
 					</section>
 
-					<section id="language-and-dir">
+					<section id="inLanguage">
 						<h5>Publication Language</h5>
 
 						<p>A <a>digital publication</a> has at least one natural language, which is the language that
@@ -1911,7 +1922,7 @@
 							<tbody>
 								<tr>
 									<td>
-										<code> inLanguage </code>
+										<code>inLanguage</code>
 									</td>
 									<td>Default <a>language</a> for the publication.</td>
 									<td>One or more <a href="https://tools.ietf.org/html/bcp47#section-2.2.9"
@@ -1976,7 +1987,7 @@
 							<tbody>
 								<tr>
 									<td>
-										<code> readingProgression </code>
+										<code>readingProgression</code>
 									</td>
 									<td>Reading progression direction from one resource to the other.</td>
 									<td>One of: <code>ltr</code> or <code>rtl</code>.</td>
@@ -2028,10 +2039,10 @@
 							<tbody>
 								<tr>
 									<td>
-										<code> name </code>
+										<code>name</code>
 									</td>
 									<td>Human-readable title of the publication.</td>
-									<td>One or more text items for the title.</td>
+									<td>One or more Text.</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-localizable-string"
 											>Localizable Strings</a>
@@ -2096,7 +2107,7 @@
 							<tbody>
 								<tr>
 									<td>
-										<code> readingOrder </code>
+										<code>readingOrder</code>
 									</td>
 									<td>Order of progression through the resources of a digital publication.</td>
 									<td>
@@ -2185,7 +2196,7 @@
 							<tbody>
 								<tr>
 									<td>
-										<code> resources </code>
+										<code>resources</code>
 									</td>
 									<td>List of additional publication resources used in the processing or rendering of
 										a publication.</td>
@@ -2275,7 +2286,7 @@
 							<tbody>
 								<tr>
 									<td>
-										<code> links </code>
+										<code>links</code>
 									</td>
 									<td>List of resources associated with a publication but not required for its
 										processing or rendering.</td>
@@ -2790,152 +2801,216 @@
 
 			<p><em>This section depends on the Infra Standard [[!infra]].</em></p>
 
-			<p>Although a <a>digital publication</a>'s manifest is authored as [[!json-ld11]], the <dfn
-					data-lt="processing the manifest|processing a manifest|process a manifest">steps for processing a
-					manifest</dfn> detailed in this section describe how a user agent <a href="#manifest-processing"
-					>processes the manifest</a> into its <a>internal representation</a> of the data. The algorithm
-				describes the process using the terminology and data types defined in [[!infra]], and, if successful
-				results in an [[!infra]] <a href="https://infra.spec.whatwg.org/#ordered-map">map</a> of the data being
-				returned.</p>
+			<section id="processing-intro" class="informative">
+				<h3>Introduction</h3>
 
-			<p class="note">An actual implementation of this algorithm will use the corresponding constructs and data
-				types of whatever language is used.</p>
+				<p>Although a <a>digital publication</a>'s manifest is authored as [[json-ld11]], the steps for
+					processing a manifest decribed in this section detail how a user agent processes the manifest into
+					its <a>internal representation</a> of the data. The algorithm describes the process using the
+					terminology and data types defined in [[infra]], and, if successful results in an [[infra]] <a
+						href="https://infra.spec.whatwg.org/#ordered-map">map</a> of the data being returned.</p>
 
-			<p>The following error types are used in this algorithm:</p>
+				<p class="note">An actual implementation of this algorithm will use the corresponding constructs and
+					data types of whatever language is used.</p>
+			</section>
 
-			<ul>
-				<li><dfn data-lt="validation errors">validation error</dfn> &#8212; a non-terminating error that occurs
-					when the <a href="https://infra.spec.whatwg.org/#map-value">value</a> of a <a
-						href="https://infra.spec.whatwg.org/#map-key">key</a> does match its expected input.</li>
-				<li><dfn data-lt="fatal errors">fatal error</dfn> &#8212; a terminating error that results, for example,
-					when a manifest cannot be processed or does not match critical validity constraints.</li>
-			</ul>
+			<section id="processing-errors">
+				<h3>Error Handling</h3>
 
-			<p>User agents SHOULD expose both validation and fatal errors, but this specification does not prescribe the
-				manner in which this is done.</p>
+				<p>The following error types are used in the <a>processing algorithm</a>:</p>
 
-			<p>The algorithm takes the following arguments:</p>
+				<ul>
+					<li><dfn data-lt="validation errors">validation error</dfn> &#8212; a non-terminating error that
+						occurs when the <a href="https://infra.spec.whatwg.org/#map-value">value</a> of a <a
+							href="https://infra.spec.whatwg.org/#map-key">key</a> does match its expected input.</li>
+					<li><dfn data-lt="fatal errors">fatal error</dfn> &#8212; a terminating error that results, for
+						example, when a manifest cannot be processed or does not match critical validity
+						constraints.</li>
+				</ul>
 
-			<ul>
-				<li><var>text</var>: a UTF-8 string containing the manifest;</li>
-				<li><var>base</var>: a URL string that represents the <a href="#manifest-base-url">base URL for the
-						manifest</a>.</li>
-				<li><var>document</var>: the <a data-cite="html#the-document-object">HTML Document (DOM)
-					Node</a>&#160;[[!html]] of the document that <a href="#manifest-discovery">references the
-						manifest</a>, when available.</li>
-			</ul>
+				<p>User agents SHOULD expose both validation and fatal errors, but this specification does not prescribe
+					the manner in which this is done.</p>
+			</section>
 
-			<p class="note">This algorithm does not define how the manifest is discovered and obtained. The steps by
-				which to do so are defined by each <a>digital publication</a> format.</p>
+			<section id="processing-algorithm">
+				<h3>Generating the Internal Reperentation</h3>
 
-			<p class="note">For illustrative purposes, the examples in this section show the structure of internal
-				representation as JavaScript objects. See also <a href="#internal-rep-data-model"></a> for a
-				visualization of the resulting structure.</p>
+				<p>This algorithm takes the following arguments:</p>
 
-			<ol>
-				<li id="processing-init">
-					<p>Let <var>processed</var> be a <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>
-						containing the <a href="#dfn-internal-representation">internal representation</a> of the
-						manifest.</p>
-				</li>
+				<ul>
+					<li><var>text</var>: a UTF-8 string representing the manifest;</li>
+					<li><var>base</var>: a URL string that represents the <a href="#manifest-base-url">base URL for the
+							manifest</a>.</li>
+					<li><var>document</var>: the <a data-cite="html#the-document-object">HTML Document (DOM)
+						Node</a>&#160;[[!html]] of the document that <a href="#manifest-discovery">references the
+							manifest</a>, when available.</li>
+				</ul>
 
-				<li id="processing-json-infra">
-					<p>Let <var>manifest</var> be the result of parsing <a
-							href="https://infra.spec.whatwg.org/#parse-json-into-infra-values">JSON into Infra
-							values</a> given <var>text</var>. If <var>manifest</var> is not a <a
-							href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>fatal error</a>, return
-						failure.</p>
-				</li>
+				<p class="note">This algorithm does not define how the manifest is discovered and obtained. The steps by
+					which to do so are defined by each <a>digital publication</a> format.</p>
 
-				<li id="processing-context">
-					<p>(<a href="#manifest-context"></a>) If <var>manifest["context"]</var> is not set to a <a
-							href="https://infra.spec.whatwg.org/#list">list</a>, or the first and second <a
-							href="https://infra.spec.whatwg.org/#list-item">items</a> in <var>manifest["@context"]</var>
-						are not the <a href="https://infra.spec.whatwg.org/#string">string</a> values
-							"<code>https://schema.org</code>" and "<code>https://www.w3.org/ns/pub-context</code>", in
-						this order, <a>fatal error</a>, return failure.</p>
-				</li>
+				<p class="note">For illustrative purposes, the examples in this section show the structure of internal
+					representation as JavaScript objects. See also <a href="#internal-rep-data-model"></a> for a
+					visualization of the resulting structure.</p>
 
-				<li id="processing-conformance">
-					<p>(<a href="#profile-conformance"></a>) Let <var>profile</var> be the <a>profile</a> the manifest
-						conforms to. Set <var>profile</var> as follows:</p>
+				<p>To <dfn data-lt="processing algorithm|processing the manifest|processing a manifest">process a
+						manifest</dfn>, run the following steps:</p>
+
+				<ol>
+					<li id="processing-init">
+						<p>Let <var>processed</var> be an empty <a href="https://infra.spec.whatwg.org/#ordered-map"
+								>map</a> that will contain the <a href="#dfn-internal-representation">internal
+								representation</a> of the manifest.</p>
+					</li>
+
+					<li id="processing-json-infra">
+						<p>Let <var>manifest</var> be the result of parsing <a
+								href="https://infra.spec.whatwg.org/#parse-json-into-infra-values">JSON into Infra
+								values</a> given <var>text</var>. If <var>manifest</var> is not a <a
+								href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>fatal error</a>, return
+							failure.</p>
+					</li>
+
+					<li id="processing-context">
+						<p>(<a href="#manifest-context"></a>) If <var>manifest["context"]</var> is not set to a <a
+								href="https://infra.spec.whatwg.org/#list">list</a>, or the first and second <a
+								href="https://infra.spec.whatwg.org/#list-item">items</a> in
+								<var>manifest["@context"]</var> are not the <a
+								href="https://infra.spec.whatwg.org/#string">string</a> values
+								"<code>https://schema.org</code>" and "<code>https://www.w3.org/ns/pub-context</code>",
+							in this order, <a>fatal error</a>, return failure.</p>
+					</li>
+
+					<li id="processing-conformance">
+						<p>(<a href="#profile-conformance"></a>) Let <var>profile</var> be the <a>profile</a> the
+							manifest conforms to. Set <var>profile</var> as follows:</p>
+						<ol>
+							<li>
+								<p>If <var>manifest["conformsTo"]</var> is not set, or does not include a profile the
+									user agent recognizes as capable of processing and/or rendering, the user agent
+									SHOULD inspect the media type(s) of the resources in the reading order to determine
+									if the publication matches a profile it is capable of processing or rendering. If
+									so, <a>validation error</a>, set <var>profile</var> to the matching profile.
+									Otherwise, <a>fatal error</a>, return failure.</p>
+							</li>
+							<li>
+								<p>Otherwise, set <var>profile</var> to the first URL in
+										<var>manifest["conformsTo"]</var> the user agent is capable of processing and/or
+									rendering.</p>
+							</li>
+						</ol>
+						<p class="note">The value of <var>manifest["conformsTo"]</var> could be a <a
+								href="https://infra.spec.whatwg.org/#string">string</a> or a <a
+								href="https://infra.spec.whatwg.org/#list">list</a> at this step in the process.</p>
+						<details>
+							<summary>Explanation</summary>
+							<p>The profile the publication conforms to determines any additional extension steps that
+								have to be performed during processing. These steps are defined by their respective
+								specifications.</p>
+						</details>
+					</li>
+
+					<li id="processing-lang-dir">
+						<p>(<a href="#manifest-lang-dir-global"></a>) Let <var>lang</var> be the global language and
+								<var>dir</var> be the global direction obtained from this step. Set each initially to an
+							empty <a href="https://infra.spec.whatwg.org/#string">string</a>.</p>
+						<p><a href="https://infra.spec.whatwg.org/#list-iterate">For each</a>
+							<var>context</var> of <var>manifest["@context"]</var>, moving from the last <a
+								href="https://infra.spec.whatwg.org/#list-item">item</a> to the first:</p>
+						<ol>
+							<li>if <var>lang</var> is an empty <a href="https://infra.spec.whatwg.org/#string"
+									>string</a> and <var>context</var> is a <a
+									href="https://infra.spec.whatwg.org/#ordered-map">map</a> that contains a
+									<var>language</var>
+								<a href="https://infra.spec.whatwg.org/#map-key">key</a>, set <var>lang</var> to
+									<var>context["language"]</var>;</li>
+							<li>if <var>dir</var> is an empty <a href="https://infra.spec.whatwg.org/#string">string</a>
+								and <var>context</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>
+								that contains a <var>direction</var>
+								<a href="https://infra.spec.whatwg.org/#map-key">key</a>, set <var>dir</var> to
+									<var>context["direction"]</var>;</li>
+							<li>if both <var>lang</var> and <var>dir</var> are not empty <a
+									href="https://infra.spec.whatwg.org/#string">strings</a>, then <a
+									href="https://infra.spec.whatwg.org/#iteration-break">break</a>.</li>
+						</ol>
+						<p>If the value of <var>lang</var> is neither an empty <a
+								href="https://infra.spec.whatwg.org/#string">string</a> nor a <a
+								href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed</a>&#160;[[!bcp47]]
+							language tag, <a>validation error</a>, set <var>lang</var> to an empty string.</p>
+						<p>If the value of <var>dir</var> is neither an empty <a
+								href="https://infra.spec.whatwg.org/#string">string</a> nor one of the values
+								"<code>ltr</code>" or "<code>rtl</code>", <a>validation error</a>, set <var>dir</var> to
+							an empty string.</p>
+						<details>
+							<summary>Explanation</summary>
+							<p>The global language and direction declarations obtained here are used to set the language
+								and base direction, respectively, for localizable strings without a declaration.</p>
+						</details>
+					</li>
+
+					<li id="processing-normalize">
+						<p><a href="https://infra.spec.whatwg.org/#map-iterate">For each</a>
+							<var>term</var> → <var>value</var> of <var>manifest</var>, set <var>processed[term]</var> to
+							the result, when successful, of calling <a>normalize data</a> given <var>term</var>,
+								<var>value</var>, <var>lang</var> and <var>dir</var>. If failure is returned, do not add
+								<var>term</var> to <var>processed</var>.</p>
+					</li>
+
+					<li id="processing-defaults">
+						<p>Set <var>processed</var> to the result of running <a>add HTML defaults</a>, when successful,
+							given <var>processed</var> and <var>document</var>. If failure is returned, terminate
+							processing, return failure.</p>
+					</li>
+
+					<li id="processing-checks">
+						<p>Set <var>processed</var> to the result of running <a>data validation</a> given
+								<var>processed</var>.</p>
+					</li>
+
+					<li id="processing-remove-empty-arrays">
+						<p><a href="https://infra.spec.whatwg.org/#map-iterate">For each</a>
+							<var>term</var> → <var>value</var> of <var>processed</var>, if running <a>remove empty
+								arrays</a> given the variables <var>term</var> and <var>value</var> returns failure, <a
+								href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+							<var>processed["term"]</var>.</p>
+						<details>
+							<summary>Explanation</summary>
+							<p>As the processing of the manifest involves removing invalid values at various stages, the
+								final data structure might end up with some lists that not no longer contain any values.
+								This step iterates back over the data and removes any such empty lists.</p>
+						</details>
+					</li>
+
+					<li id="processing-end">
+						<p>Return <var>processed</var>.</p>
+					</li>
+				</ol>
+
+				<section id="normalize-data">
+					<h4>Data Normalization</h4>
+
+					<p class="note">The following steps depend on the expected value category of a term. Exercise
+						caution when processing terms as value categories depend not only on the name of the term, but
+						also on the object it is used with. For example, the value category for the term <a
+							href="#address"><code>url</code></a> is an <a href="#value-array">Array</a> (of URLs) when
+						the direct property of the Publication Manifest, but a single URL literal when used in other
+						objects.</p>
+
+					<p>To <dfn>normalize data</dfn> for a property <var>term</var>'s <var>value</var>, with optional <a
+							href="https://infra.spec.whatwg.org/#string">strings</a>
+						<var>language</var> and <var>direction</var>, run these steps:</p>
+
 					<ol>
-						<li>If <var>manifest["conformsTo"]</var> is not set, <a>validation error</a>, set to
-								<code>«&#160;"https://www.w3.org/TR/pub-manifest"&#160;»</code>.</li>
-						<li>If <var>manifest["conformsTo"]</var> does not include a URL of a profile the user agent is
-							capable of processing and/or rendering, <a>fatal error</a>, return failure.</li>
-						<li>If <var>manifest["conformsTo"]</var> includes the URLs of more than one profile the user
-							agent is capable of processing and/or rendering, set to the first in the array in the case
-							of conflicting requirements.</li>
-						<li>Otherwise, set to the profile defined by the URL the user agent is capable of processing
-							and/or rendering.</li>
-					</ol>
-					<details>
-						<summary>Explanation</summary>
-						<p>The profile the publication conforms to determines any additional extension steps that have
-							to be performed during processing. These steps are defined by their respective
-							specifications.</p>
-					</details>
-				</li>
-
-				<li id="processing-lang-dir">
-					<p>(<a href="#manifest-lang-dir-global"></a>) Let <var>lang</var> be the global language and
-							<var>dir</var> be the global direction obtained from this step. Set each initially to an
-						empty <a href="https://infra.spec.whatwg.org/#string">string</a>.</p>
-					<p><a href="https://infra.spec.whatwg.org/#list-iterate">For each</a>
-						<var>context</var> of <var>manifest["@context"]</var>, moving from the last <a
-							href="https://infra.spec.whatwg.org/#list-item">item</a> to the first:</p>
-					<ol>
-						<li>if <var>lang</var> is an empty <a href="https://infra.spec.whatwg.org/#string">string</a>
-							and <var>context</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>
-							that contains a <var>language</var>
-							<a href="https://infra.spec.whatwg.org/#map-key">key</a>, set <var>lang</var> to
-								<var>context["language"]</var>;</li>
-						<li>if <var>dir</var> is an empty <a href="https://infra.spec.whatwg.org/#string">string</a> and
-								<var>context</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>
-							that contains a <var>direction</var>
-							<a href="https://infra.spec.whatwg.org/#map-key">key</a>, set <var>dir</var> to
-								<var>context["direction"]</var>;</li>
-						<li>if both <var>lang</var> and <var>dir</var> are not empty <a
-								href="https://infra.spec.whatwg.org/#string">strings</a>, then <a
-								href="https://infra.spec.whatwg.org/#iteration-break">break</a>.</li>
-					</ol>
-					<p>If the value of <var>lang</var> is neither an empty <a
-							href="https://infra.spec.whatwg.org/#string">string</a> nor a <a
-							href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed</a>&#160;[[!bcp47]]
-						language tag, <a>validation error</a>, set <var>lang</var> to an empty string.</p>
-					<p>If the value of <var>dir</var> is neither an empty <a
-							href="https://infra.spec.whatwg.org/#string">string</a> nor one of the values
-							"<code>ltr</code>" or "<code>rtl</code>", <a>validation error</a>, set <var>dir</var> to an
-						empty string.</p>
-					<details>
-						<summary>Explanation</summary>
-						<p>The global language and direction declarations obtained here are used to set the language and
-							base direction, respectively, for localizable strings without a declaration.</p>
-					</details>
-				</li>
-
-				<li id="processing-normalize">
-					<p>Normalize <var>manifest</var> as follows.</p>
-					<p class="note">The following steps depend on the expected value category of a <var>term</var>.
-						Exercise caution when processing terms as value categories depend not only on the name of the
-						term, but also on the object it is used with. For example, the value category for the term
-							<code>url</code> is an <a href="#value-array">Array</a> (of URLs) when used for the
-							<code>PublicationManifest</code> object, but a single URL literal otherwise.</p>
-					<p><a href="https://infra.spec.whatwg.org/#map-iterate">For each</a>
-						<var>term</var> → <var>termValue</var> of <var>manifest</var>:</p>
-					<ol>
-						<li id="processing-normalize-init">
-							<p>Let <var>normalized</var> be the value of <var>termValue</var>.</p>
+						<li id="normalize-init">
+							<p>Let <var>normalized</var> be the value of <var>value</var>.</p>
 						</li>
 
-						<li id="processing-normalize-arrays">
+						<li id="normalize-arrays">
 							<p>(<a href="#value-array"></a>) If <var>term</var> expects an <a href="#value-array"
-									>array</a> and <var>termValue</var> is a <a
-									href="https://infra.spec.whatwg.org/#string">string</a>, <a
-									href="https://infra.spec.whatwg.org/#boolean">boolean</a>, number, or <a
-									href="https://infra.spec.whatwg.org/#ordered-map">map</a>, set <var>normalized</var>
-								to «&#160;<var>termValue</var>&#160;».</p>
+									>array</a> and <var>value</var> is a <a href="https://infra.spec.whatwg.org/#string"
+									>string</a>, <a href="https://infra.spec.whatwg.org/#boolean">boolean</a>, number,
+								or <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>, set
+									<var>normalized</var> to «&#160;<var>value</var>&#160;».</p>
 							<details>
 								<summary>Explanation</summary>
 								<p>A number of terms require their values to be arrays, but, for the sake of
@@ -2957,10 +3032,11 @@
 							</details>
 						</li>
 
-						<li id="processing-normalize-entities">
+						<li id="normalize-entities">
 							<p>(<a href="#value-entity"></a>) If <var>term</var> expects an <a href="#value-array"
-									>array</a> of <a href="#value-entity">entities</a>, <a>for each</a>
-								<var>entity</var> in <var>normalized</var>:</p>
+									>array</a> of <a href="#value-entity">entities</a>, <a
+									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+								<var>entity</var> of <var>normalized</var>:</p>
 							<ol>
 								<li>
 									<p>if <var>entity</var> is a <a href="https://infra.spec.whatwg.org/#string"
@@ -2968,7 +3044,7 @@
 											href="https://infra.spec.whatwg.org/#ordered-map">map</a>:</p>
 									<pre>«[
     "type" → « "Person" »,
-    "name" → <var>termValue</var>
+    "name" → <var>value</var>
 ]»</pre>
 								</li>
 								<li>
@@ -3006,67 +3082,55 @@
 							</details>
 						</li>
 
-						<li id="processing-normalize-localizable-strings">
-							<p>(<a href="#value-localizable-string"></a>) If <var>term</var> expects a <a
-									href="#value-localizable-string">localizable string</a>:</p>
+						<li id="normalize-localizable-strings">
+							<p>(<a href="#value-localizable-string"></a>) If <var>term</var> expects an <a
+									href="#value-array">array</a> of localizable strings, <a
+									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+								<var>item</var> of <var>normalized</var>:</p>
 							<ol>
 								<li id="ls-value-normalize">
-									<p>if <var>termValue</var> is a <a href="https://infra.spec.whatwg.org/#string"
-											>string</a>, set <var>normalized</var> to the <a
+									<p>if <var>itemString</var> is a <a href="https://infra.spec.whatwg.org/#string"
+											>string</a>, set <var>item</var> to the <a
 											href="https://infra.spec.whatwg.org/#ordered-map">map</a>:</p>
 									<pre>«[
-    "value" → <var>termValue</var>,
-    "language" → <var>lang</var>,
-    "direction" → <var>dir</var>
+    "value" → <var>value</var>,
+    "language" → <var>language</var>,
+    "direction" → <var>direction</var>
 ]»</pre>
-									<p>If the value of <var>lang</var> or <var>dir</var> is an empty <a
-											href="https://infra.spec.whatwg.org/#string">string</a>, <a
+									<p>if <var>language</var> or <var>direction</var> is not set, or is an empty <a
+											href="https://infra.spec.whatwg.org/#string">strings</a>, <a
 											href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-										<var>normalized["language"]</var> or <var>normalized["direction"]</var>,
-										respectively, from the <a href="https://infra.spec.whatwg.org/#ordered-map"
-											>map</a>.</p>
+										<var>item["language"]</var> or <var>item["direction"]</var>, respectively.</p>
 								</li>
-								<li>
-									<p>otherwise, if <var>termValue</var> is number, <a
+								<li id="ls-error">
+									<p>otherwise, if <var>item</var> is number, <a
 											href="https://infra.spec.whatwg.org/#boolean">boolean</a> or <a
 											href="https://infra.spec.whatwg.org/#nulls">null</a>, <a>validation
-											error</a> then <a href="https://infra.spec.whatwg.org/#iteration-continue"
-											>continue</a>.</p>
+											error</a>, remove <var>item</var> from <var>normalized</var>.</p>
 								</li>
 								<li id="ls-map-normalize">
-									<p>otherwise, if <var>termValue</var> is a <a
+									<p>otherwise, if <var>item</var> is a <a
 											href="https://infra.spec.whatwg.org/#ordered-map">map</a>:</p>
-									<ul>
+									<ol>
 										<li>
-											<p>if <var>termValue["language"]</var> is not set, set it to the value of
-													<var>lang</var> when <var>lang</var> is not an empty <a
-													href="https://infra.spec.whatwg.org/#string">string</a>.</p>
-										</li>
-										<li>
-											<p>otherwise, if the value of <var>termValue["language"]</var> is <a
+											<p>if <var>item["language"]</var> is not set, set it to the value of
+													<var>language</var> when <var>language</var> is set and is not an
+												empty <a href="https://infra.spec.whatwg.org/#string">string</a>.</p>
+											<p>otherwise, <var>item["language"]</var> is <a
 													href="https://infra.spec.whatwg.org/#nulls">null</a>, <a
 													href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-												<var>termValue["language"]</var>.</p>
+												<var>item["language"]</var>.</p>
 										</li>
 										<li>
-											<p>if <var>termValue["direction"]</var> is not set, set it to the value of
-													<var>dir</var> when <var>dir</var> is not an empty <a
-													href="https://infra.spec.whatwg.org/#string">string</a>.</p>
-										</li>
-										<li>
-											<p>otherwise, if the value of <var>termValue["direction"]</var> is <a
+											<p>if <var>item["direction"]</var> is not set, set it to the value of
+													<var>direction</var> when <var>direction</var> is set and is not an
+												empty <a href="https://infra.spec.whatwg.org/#string">string</a>.</p>
+											<p>otherwise, if <var>item["direction"]</var> is <a
 													href="https://infra.spec.whatwg.org/#nulls">null</a>, <a
 													href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-												<var>termValue["direction"]</var>.</p>
+												<var>item["direction"]</var>.</p>
 										</li>
-									</ul>
-								</li>
-								<li>
-									<p>otherwise, if <var>value</var> is a <a href="https://infra.spec.whatwg.org/#list"
-											>list</a>, process each <a href="https://infra.spec.whatwg.org/#list-item"
-											>item</a> per its respective <a href="#ls-value-normalize">single-value
-											normalization</a> or <a href="#ls-map-normalize">map normalization</a> step.
-										Process each nested list encountered in the same way.</p>
+									</ol>
 								</li>
 							</ol>
 							<details>
@@ -3160,10 +3224,11 @@
 							</details>
 						</li>
 
-						<li id="processing-normalize-links">
-							<p>(<a href="#value-linked-resource"></a>) If <var>term</var> is a <a
-									href="#resource-categorization-properties">resource categorization property</a>, <a
-									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+						<li id="normalize-linked-resources">
+							<p>(<a href="#value-linked-resource"></a>) If <var>term</var> expects an <a
+									href="#value-array">array</a> of <a href="#value-linked-resource"
+									>LinkedResources</a>, <a href="https://infra.spec.whatwg.org/#list-iterate">for
+									each</a>
 								<var>resource</var> of <var>normalized</var>:</p>
 							<ol>
 								<li>
@@ -3175,13 +3240,10 @@
 ]»</pre>
 								</li>
 								<li>
-									<p>otherwise, if <var>resource</var> is a <a
-											href="https://infra.spec.whatwg.org/#ordered-map">map</a> and contains an <a
-											href="#linkedresource-alternate"><code>alternate</code></a>
-										<a href="https://infra.spec.whatwg.org/#map-key">key</a>, run <a
-											href="#processing-normalize-links">this step</a> on each <a
-											href="https://infra.spec.whatwg.org/#list-item">item</a> in
-											<var>resource["alternate"]</var> to convert any string values. </p>
+									<p>otherwise, if <var>resource</var> is number, <a
+											href="https://infra.spec.whatwg.org/#boolean">boolean</a> or <a
+											href="https://infra.spec.whatwg.org/#nulls">null</a>, <a>validation
+											error</a>, remove <var>resource</var> from <var>normalized</var>.</p>
 								</li>
 							</ol>
 							<details>
@@ -3215,7 +3277,7 @@
 							</details>
 						</li>
 
-						<li id="processing-normalize-urls">
+						<li id="normalize-urls">
 							<p>(<a href="#value-url"></a>) If <var>term</var> expects a <a href="#value-url">URL</a></p>
 							<ol>
 								<li>
@@ -3239,12 +3301,12 @@
 							</details>
 						</li>
 
-						<li id="processing-normalize-extension">
+						<li id="normalize-extension">
 							<p>(<a href="#extensions"></a>, extension point) if a <a>profile</a> defines processing
 								steps for profile-specific terms, those steps are executed at this point.</p>
 						</li>
 
-						<li id="processing-normalize-recurse-lists">
+						<li id="normalize-recurse-lists">
 							<p>if <var>normalized</var> is a <a href="https://infra.spec.whatwg.org/#list">list</a>, <a
 									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
 								<var>item</var> of <var>normalized</var> that is a <a
@@ -3254,7 +3316,8 @@
 								result of running <a href="#processing-normalize">this step</a> on
 								<var>keyValue</var>.</p>
 						</li>
-						<li id="processing-normalize-recurse-maps">
+
+						<li id="normalize-recurse-maps">
 							<p>if <var>normalized</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
 									>map</a>, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
 								<var>key</var> → <var>keyValue</var> of <var>normalized</var>, set <var>key</var> to the
@@ -3262,18 +3325,24 @@
 								<var>keyValue</var>.</p>
 						</li>
 
-						<li id="processing-normalize-end">
-							<p>Set <var>processed[term]</var> to the value of <var>normalized</var>.</p>
+						<li id="normalize-end">
+							<p>return <var>normalized</var>.</p>
 						</li>
 					</ol>
-				</li>
 
-				<li id="processing-defaults">
-					<p>Add defaults from <var>document</var> for the following properties, when applicable:</p>
+				</section>
+
+				<section id="add-html-defaults">
+					<h3>Add HTML Default Values</h3>
+
+					<p>To <dfn>add HTML defaults</dfn> for missing properties in <a
+							href="https://infra.spec.whatwg.org/#ordered-map">map</a>
+						<var>data</var> with a HTML document node <var>document</var>, run the following steps:</p>
+
 					<ol>
 						<li id="processing-defaults-title">
-							<p>(<a href="#pub-title"></a>) If <var>processed["name"]</var> is not set, or its value is
-								an empty <a href="https://infra.spec.whatwg.org/#string">string</a>:</p>
+							<p>(<a href="#pub-title"></a>) If <var>data["name"]</var> is not set, or its value is an
+								empty <a href="https://infra.spec.whatwg.org/#string">string</a>:</p>
 							<ul>
 								<li>
 									<p>Let <var>title</var> be an empty <a
@@ -3281,11 +3350,12 @@
 										follows:</p>
 									<ul>
 										<li>
-											<p> if the <a data-cite="html#the-title-element"><code>title</code></a>
+											<p>if the <a data-cite="html#the-title-element"><code>title</code></a>
 												element&#160;[[!html]] of <var>document</var> is set and its contains is
 												not empty, set <var>title["value"]</var> to the text content of the
-													<code>title</code> element. Set <var>title["language"]</var> to the
-													<a data-cite="html#the-lang-and-xml:lang-attributes"
+													<code>title</code> element.</p>
+											<p>Set <var>title["language"]</var> to the <a
+													data-cite="html#the-lang-and-xml:lang-attributes"
 												>language</a>&#160;[[!html]], if available, and
 													<var>title["direction"]</var> to the <a
 													data-cite="html#the-dir-attribute">base direction</a>&#160;[[!html]]
@@ -3295,12 +3365,13 @@
 										<li>
 											<p>otherwise, <a>validation error</a>, generate a value for
 													<var>title["value"]</var> (see the <a href="#generate_title"
-													>separate note for details</a>).</p>
+													>separate note for details</a>). Set <var>title["language"]</var>
+												and <var>title["direction"]</var> as approrpriate for the generated
+												title.</p>
 										</li>
 									</ul>
 								</li>
-								<li>Set <var>processed["name"]</var> to
-									<code>«&#160;<var>title</var>&#160;»</code>.</li>
+								<li>Set <var>data["name"]</var> to <code>«&#160;<var>title</var>&#160;»</code>.</li>
 							</ul>
 							<details>
 								<summary>Explanation</summary>
@@ -3332,16 +3403,16 @@
 						</li>
 
 						<li id="processing-defaults-reading-order">
-							<p>(<a href="#default-reading-order"></a>) If <var>processed["readingOrder"]</var> is not
-								set or its value is an empty <a href="https://infra.spec.whatwg.org/#string">string</a>
-								or <a href="https://infra.spec.whatwg.org/#list">list</a>:</p>
+							<p>(<a href="#default-reading-order"></a>) If <var>data["readingOrder"]</var> is not set or
+								its value is an empty <a href="https://infra.spec.whatwg.org/#string">string</a> or <a
+									href="https://infra.spec.whatwg.org/#list">list</a>:</p>
 							<ul>
 								<li>
 									<p>if <a data-cite="!dom#concept-document-url">document.URL</a> is not set, this is
 										a <a>fatal error</a>. Return failure.</p>
 								</li>
 								<li>
-									<p>otherwise, set <var>processed["readingOrder"]</var> to an empty <a
+									<p>otherwise, set <var>data["readingOrder"]</var> to an empty <a
 											href="https://infra.spec.whatwg.org/#list">list</a> and <a
 											href="https://infra.spec.whatwg.org/#list-append">append</a> the <a
 											href="https://infra.spec.whatwg.org/#ordered-map">map</a>
@@ -3361,170 +3432,301 @@
 							<p>If a <a>profile</a> specifies <var>document</var> fallbacks, those steps are executed at
 								this point.</p>
 						</li>
+
+						<li>
+							<p>Return <var>data</var>.</p>
+						</li>
 					</ol>
-				</li>
+				</section>
 
-				<li id="processing-checks">
-					<p>Perform data integrity checks on <var>processed</var> as follows:</p>
+				<section id="validate-data">
+					<h3>Data Validation</h3>
+
+					<p>To perform <dfn>data validation</dfn> on <a href="https://infra.spec.whatwg.org/#ordered-map"
+							>map</a>
+						<var>data</var>, run the following steps:</p>
+
 					<ol>
-						<li id="processing-checks-general">
+						<li id="validate-general">
 							<p><a href="https://infra.spec.whatwg.org/#map-iterate">For each</a>
-								<var>term</var> → <var>termValue</var> in <var>processed</var>:</p>
-							<ol>
-								<li id="processing-checks-values">
-									<p>(<a href="#properties-value-categories"></a>) If <var>term</var> has a known <a
-											href="#properties-value-categories">value type</a>, and <var>termValue</var>
-										does not match the expected type, <a>validation error</a>, <a
-											href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-										<var>processed[term]</var>.</p>
-								</li>
-
-								<li id="processing-checks-entities">
-									<p>(<a href="#value-entity"></a>) If <var>term</var> expects an <a
-											href="#value-array">array</a> of <a href="#value-entity">entities</a>, <a
-											href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-										<var>item</var> of <var>termValue</var>, check whether <var>item["name"]</var>
-										is set:</p>
-									<ul>
-										<li>
-											<p>If not, <a>validation error</a>, <a
-													href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-												<var>item</var> from <var>termValue</var>.</p>
-										</li>
-										<li>If so, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-											<var>name</var> of <var>item["name"]</var>, if <var>name["value"]</var> is
-											not set, or is an empty string, <a
-												href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-											<var>name</var> from <var>item["name"]</var>.</li>
-									</ul>
-								</li>
-
-								<li id="processing-checks-language">
-									<p>(<a href="#manifest-lang-dir-global"></a> and <a href="#manifest-lang-dir-local"
-										></a>) If <var>termValue</var> is a <a
-											href="https://infra.spec.whatwg.org/#ordered-map">map</a>:</p>
-									<ul>
-										<li>
-											<p>if it <var>termValue["language"]</var> is set and its value is not <a
-													href="https://tools.ietf.org/html/bcp47#section-2.2.9"
-													>well-formed</a>&#160;[[!bcp47]], <a>validation error</a>, <a
-													href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-												<var>termValue["language"]</var>.</p>
-											<p>if <var>termValue["direction"]</var> is set and its value is not one of
-													"<code>ltr</code>" or "<code>rtl</code>", <a>validation error</a>,
-													<a href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-												<var>termValue["direction"]</var>.</p>
-										</li>
-									</ul>
-								</li>
-
-								<li id="processing-checks-linkedresource">
-									<p>(<a href="#value-linked-resource"></a>) If <var>processed[term]</var> expects an
-											<a href="#value-array">array</a> of <a href="#LinkedResource-def"
-											>LinkedResource</a>, <a href="https://infra.spec.whatwg.org/#list-iterate"
-											>for each</a>
-										<var>resource</var> of <var>termValue</var>:</p>
-									<ul>
-										<li>
-											<p>if <var>resource["url"]</var> is not set, or its value is an empty
-												string, <a>validation error</a>, <a
-													href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-												<var>item</var> from <var>termValue</var>.</p>
-											<p>Otherwise, if <var>resource["url"]</var> is not a valid
-												URL&#160;[[!url]], <a>validation error</a>, <a
-													href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-												<var>item</var> from <var>termValue</var>.</p>
-										</li>
-										<li>
-											<p>if <a href="#linkedresource-length"><var>resource["length"]</var></a> is
-												set and is not a number, or is a negative number, <a>validation
-													error</a>, <a href="https://infra.spec.whatwg.org/#map-remove"
-													>remove</a>
-												<var>resource["length"]</var>.</p>
-										</li>
-										<li>
-											<p>if <a href="#linkedresource-alternate"
-													><var>resource["alternate"]</var></a> is set, <a
-													href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-												<var>alternate</var> of <var>resource["alterate"]</var>, if
-													<var>alternate["encodingFormat"]</var> is not set, <a>validation
-													error</a>.</p>
-										</li>
-									</ul>
-								</li>
-
-								<li id="processing-checks-recursion">
-									<p>If <var>term</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
-											>map</a> or <a href="https://infra.spec.whatwg.org/#list">list</a>, process
-										its <a href="https://infra.spec.whatwg.org/#map-key">keys</a> or <a
-											href="https://infra.spec.whatwg.org/#list-item">items</a>, respectively as
-										defined by <a href="#processing-checks-general">this iterator</a>.</p>
-								</li>
-							</ol>
+								<var>term</var> → <var>value</var> of <var>data</var>, set <var>term</var> to the result
+								of running the <a>common data checks</a>, when successful, given <var>term</var> and
+									<var>value</var>. If a failure occurs, remove <var>data[term]</var>.</p>
 						</li>
 
-						<li id="processing-checks-type">
-							<p>(<a href="#publication-types"></a>) If <var>processed["type"]</var> is not set or is an
-								empty <a href="https://infra.spec.whatwg.org/#list">list</a>, <a>validation error</a>,
-								set to <code>«&#160;"CreativeWork"&#160;»</code>.</p>
+						<li id="validate-type">
+							<p>(<a href="#publication-types"></a>) If <var>data["type"]</var> is not set or is an empty
+									<a href="https://infra.spec.whatwg.org/#list">list</a>, <a>validation error</a>, set
+								to <code>«&#160;"CreativeWork"&#160;»</code>.</p>
 						</li>
 
-						<li id="processing-checks-abridged">
-							<p>(<a href="#abridged"></a>) If <var>processed["abridged"]</var> is set and is not a <a
+						<li id="validate-abridged">
+							<p>(<a href="#abridged"></a>) If <var>data["abridged"]</var> is set and is not a <a
 									href="https://infra.spec.whatwg.org/#boolean">boolean</a>, <a>validation error</a>,
 									<a href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-								<var>processed["abridged"]</var>.</p>
+								<var>data["abridged"]</var>.</p>
 						</li>
 
-						<li id="processing-checks-duration">
-							<p>(<a href="#duration"></a>) If <var>processed["duration"]</var> is set and is not a valid
+						<li id="validate-ams">
+							<p>(<a href="#accessibility"></a>) If <var>data["accessModeSufficient"]</var> is set, <a
+									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+								<var>ams</var> of <var>data["accessModeSufficient"]</var>, if <var>ams["type"]</var> is
+								not set or is not "<code>ItemList</code>", <a
+									href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+								<var>ams</var> from <var>data["accessModeSufficient"]</var>.</p>
+						</li>
+
+						<li id="validate-duration">
+							<p>(<a href="#duration"></a>) If <var>data["duration"]</var> is set and is not a valid
 								duration value, per&#160;[[!iso8601]], <a>validation error</a>, <a
 									href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-								<var>processed["duration"]</var>.</p>
+								<var>data["duration"]</var>.</p>
 						</li>
 
-						<li id="processing-checks-last-mod">
-							<p>(<a href="#last-modification-date"></a>) If <var>processed["dateModified"]</var> is set
-								and is not a valid date or date-time per&#160;[[!iso8601]], <a>validation error</a>, <a
-									href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-								<var>processed["dateModified"]</var>.</p>
-						</li>
-
-						<li id="processing-checks-pub-date">
-							<p>(<a href="#publication-date"></a>) If <var>processed["datePublished"]</var> is set and is
+						<li id="validate-last-mod">
+							<p>(<a href="#last-modification-date"></a>) If <var>data["dateModified"]</var> is set and is
 								not a valid date or date-time per&#160;[[!iso8601]], <a>validation error</a>, <a
 									href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-								<var>processed["datePublished"]</var>.</p>
+								<var>data["dateModified"]</var>.</p>
 						</li>
 
-						<li id="processing-checks-inlanguage">
-							<p>(<a href="#language-and-dir"></a>) If <var>processed["inLanguage"]</var> is set, <a
+						<li id="validate-pub-date">
+							<p>(<a href="#publication-date"></a>) If <var>data["datePublished"]</var> is set and is not
+								a valid date or date-time per&#160;[[!iso8601]], <a>validation error</a>, <a
+									href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+								<var>data["datePublished"]</var>.</p>
+						</li>
+
+						<li id="validate-inlanguage">
+							<p>(<a href="#inLanguage"></a>) If <var>data["inLanguage"]</var> is set, <a
 									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-								<var>item</var> of <var>processed["inLanguage"]</var>, if <var>item</var> is not <a
+								<var>item</var> of <var>data["inLanguage"]</var>, if <var>item</var> is not <a
 									href="https://tools.ietf.org/html/bcp47#section-2.2.9"
 								>well-formed</a>&#160;[[!bcp47]], <a>validation error</a>, <a
 									href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-								<var>item</var> from <var>processed["inLanguage"]</var>.</p>
+								<var>item</var> from <var>data["inLanguage"]</var>.</p>
 						</li>
 
-						<li id="processing-checks-progression-dir">
-							<p>(<a href="#reading-progression-direction"></a>) If
-									<var>processed["readingProgression"]</var> is not set, or is not one of the <a
-									href="#reading-progression-direction">required directional values</a>, <a>validation
-									error</a>, set to "<code>ltr</code>".</p>
+						<li id="validate-progression-dir">
+							<p>(<a href="#reading-progression-direction"></a>) If <var>data["readingProgression"]</var>
+								is not set, or is not one of the <a href="#reading-progression-direction">required
+									directional values</a>, <a>validation error</a>, set to "<code>ltr</code>".</p>
 						</li>
 
-						<li id="processing-checks-extension">
+						<li id="validate-extension">
 							<p>If a <a>profile</a> specifies data validation checks, those steps are executed at this
 								point.</p>
 						</li>
-					</ol>
-				</li>
 
-				<li id="processing-end">
-					<p>Return <var>processed</var>.</p>
-				</li>
-			</ol>
+						<li id="validate-end">
+							<p>Return <var>data</var>.</p>
+						</li>
+					</ol>
+				</section>
+
+				<section id="common-data-checks">
+					<h4>Common Data Checks</h4>
+
+					<p>To process the <dfn>common data checks</dfn> on a property <var>term</var>'s <var>value</var>,
+						run these steps:</p>
+
+					<ol>
+						<li id="common-checks-value-categories">
+							<p>(<a href="#properties-value-categories"></a>) If <var>term</var> has a known <a
+									href="#properties-value-categories">value category</a>, set <var>value</var> to the
+								result of calling <a href="#category-check">value category check</a> given the variables
+									<var>term</var> and <var>value</var>.</p>
+						</li>
+						<li id="common-checks-entities">
+							<p>(<a href="#value-entity"></a>) If <var>term</var> expects an <a href="#value-array"
+									>array</a> of <a href="#value-entity">entities</a>, <a
+									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+								<var>item</var> of <var>value</var>, check whether <var>item["name"]</var> is set:</p>
+							<ul>
+								<li>
+									<p>If not, <a>validation error</a>, <a
+											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+										<var>item</var> from <var>value</var>.</p>
+								</li>
+								<li>If so, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+									<var>name</var> of <var>item["name"]</var>, if <var>name["value"]</var> is not set,
+									or is an empty string, <a href="https://infra.spec.whatwg.org/#list-remove"
+										>remove</a>
+									<var>name</var> from <var>item["name"]</var>.</li>
+							</ul>
+						</li>
+
+						<li id="common-checks-language">
+							<p>(<a href="#manifest-lang-dir-global"></a> and <a href="#manifest-lang-dir-local"></a>) If
+									<var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
+								>map</a>:</p>
+							<ul>
+								<li>
+									<p>if <var>value["language"]</var> is set and its value is not <a
+											href="https://tools.ietf.org/html/bcp47#section-2.2.9"
+										>well-formed</a>&#160;[[!bcp47]], <a>validation error</a>, <a
+											href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+										<var>value["language"]</var>.</p>
+									<p>if <var>value["direction"]</var> is set and its value is not one of
+											"<code>ltr</code>" or "<code>rtl</code>", <a>validation error</a>, <a
+											href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+										<var>value["direction"]</var>.</p>
+								</li>
+							</ul>
+						</li>
+
+						<li id="common-checks-linkedresource">
+							<p>(<a href="#value-linked-resource"></a>) If <var>term</var> expects an <a
+									href="#value-array">array</a> of <a href="#LinkedResource-def">LinkedResource</a>,
+									<a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+								<var>resource</var> of <var>value</var>:</p>
+							<ul>
+								<li>
+									<p>if <var>resource["url"]</var> is not set, or its value is an empty string,
+											<a>validation error</a>, <a
+											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+										<var>item</var> from <var>value</var>.</p>
+									<p>Otherwise, if <var>resource["url"]</var> is not a valid URL&#160;[[!url]],
+											<a>validation error</a>, <a
+											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+										<var>item</var> from <var>value</var>.</p>
+								</li>
+								<li>
+									<p>if <a href="#linkedresource-length"><var>resource["length"]</var></a> is set and
+										is not a number, or is a negative number, <a>validation error</a>, <a
+											href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+										<var>resource["length"]</var>.</p>
+								</li>
+								<li>
+									<p>if <a href="#linkedresource-alternate"><var>resource["alternate"]</var></a> is
+										set, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+										<var>alternate</var> of <var>resource["alterate"]</var>, if
+											<var>alternate["encodingFormat"]</var> is not set, <a>validation
+										error</a>.</p>
+								</li>
+							</ul>
+						</li>
+
+						<li id="common-checks-recurse-maps">
+							<p>If <var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
+									href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+								<var>key</var> → <var>keyValue</var> of <var>value</var>, set <var>value[key]</var> to
+								the result of running <a>common data checks</a> given <var>key</var> and
+									<var>keyValue</var>.</p>
+						</li>
+
+						<li id="common-checks-recurse-lists">
+							<p>If <var>value</var> is a <a href="https://infra.spec.whatwg.org/#list">list</a>, <a
+									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+								<var>item</var> of <var>value</var>, if <var>item</var> is a <a
+									href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
+									href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+								<var>key</var> → <var>keyValue</var> of <var>value</var>, set <var>value[key]</var> to
+								the result of running <a>common data checks</a> given <var>key</var> and
+									<var>keyValue</var>.</p>
+						</li>
+
+						<li id="common-check-end">
+							<p>Return <var>value</var>.</p>
+						</li>
+					</ol>
+				</section>
+
+				<section id="category-check">
+					<h4>Value Category Check</h4>
+
+					<p>To <dfn>check the category</dfn> of a property <var>term</var>'s <var>value</var>, run these
+						steps:</p>
+
+					<ol>
+						<li>
+							<p>If <var>term</var> expects an <a href="#value-array">array</a>:</p>
+							<ol>
+								<li>
+									<p>if <var>value</var> is not a <a href="https://infra.spec.whatwg.org/#list"
+											>list</a>, <a>validation error</a>, return failure.</p>
+								</li>
+								<li>
+									<p>otherwise, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+										<var>item</var> of <var>value</var>:</p>
+									<ol>
+										<li>
+											<p>if <var>item</var> does not match the expected type of the array,
+													<a>validation error</a>, <a
+													href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+												<var>item</var> from <var>value</var>.</p>
+										</li>
+										<li>
+											<p>if <var>item</var> is a <a
+													href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
+													href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+												<var>key</var> → <var>keyValue</var> of <var>item</var>, if
+													<var>key</var> has an expected type, set <var>key</var> to the
+												result of running <a href="#category-check">check category type</a>
+												given the variables <var>key</var> and <var>keyValue</var>. If the
+												result of processing <var>item</var> is an empty <a
+													href="https://infra.spec.whatwg.org/#ordered-map">map</a>,
+													<a>validation error</a>, <a
+													href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+												<var>item</var> from <var>value</var>.</p>
+										</li>
+									</ol>
+									<p>If the result of processing <var>value</var> is an empty <a href="#value-array"
+											>array</a>, <a>validation error</a>, return failure.</p>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<p>Otherwise, if <var>term</var> expects a <a
+									href="https://infra.spec.whatwg.org/#ordered-map">map</a>:</p>
+							<ol>
+								<li>
+									<p>if <var>value</var> is not a <a href="https://infra.spec.whatwg.org/#ordered-map"
+											>map</a>, <a>validation error</a>, return failure.</p>
+								</li>
+								<li>
+									<p>otherwise, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+										<var>key</var> → <var>keyValue</var> of <var>value</var>, if <var>key</var> has
+										an expected type, set <var>key</var> to the result of running <a
+											href="#category-check">check category type</a> given <var>key</var> and
+											<var>keyValue</var>. If the result of processing <var>value</var> is an
+										empty <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>,
+											<a>validation error</a>, return failure.</p>
+								</li>
+							</ol>
+						</li>
+						<li>
+							<p>Otherwise, if <var>value</var> does not have the expected type of <var>term</var>,
+									<a>validation error</a>, return failure.</p>
+						</li>
+						<li>
+							<p>Return <var>value</var>.</p>
+						</li>
+					</ol>
+				</section>
+
+				<section id="remove-empty-arrays">
+					<h4>Remove Empty Arrays</h4>
+
+					<p>To <dfn>remove empty arrays</dfn> from a property <var>term</var>'s <var>value</var>, run these
+						steps:</p>
+
+					<ol>
+						<li>
+							<p>If <var>value</var> is an empty <a href="https://infra.spec.whatwg.org/#list">list</a>,
+								return failure.</p>
+						</li>
+						<li>
+							<p>Otherwise, if <var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
+									>map</a>, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+								<var>key</var> → <var>keyValue</var> of <var>value</var>, if running <a>remove empty
+									arrays</a> given <var>key</var> and <var>keyValue</var> returns failure, <a
+									href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+								<var>value[key]</var>.</p>
+						</li>
+					</ol>
+				</section>
+			</section>
 		</section>
 		<section id="extensions">
 			<h2>Modular Extensions</h2>
@@ -3619,7 +3821,7 @@ dictionary PublicationManifest {
              sequence&lt;DOMString>         accessModeSufficient;
              sequence&lt;DOMString>         accessibilityFeature;
              sequence&lt;DOMString>         accessibilityHazard;
-             LocalizableString           accessibilitySummary;
+             sequence&lt;LocalizableString> accessibilitySummary;
              sequence&lt;Entity>            artist;
              sequence&lt;Entity>            author;
              sequence&lt;Entity>            colorist;
@@ -3658,7 +3860,7 @@ dictionary LinkedResource {
     required DOMString                           url;
              DOMString                           encodingFormat;
              sequence&lt;LocalizableString>         name;
-             LocalizableString                   description;
+             sequence&lt;LocalizableString>         description;
              sequence&lt;DOMString>                 rel;
              DOMString                           integrity;
              double                              length;
@@ -4560,7 +4762,7 @@ dictionary LocalizableString {
 							<code>inLanguage</code>
 						</td>
 						<td>
-							<a href="#language-and-dir"></a>
+							<a href="inLaguage"></a>
 						</td>
 					</tr>
 					<tr>

--- a/index.html
+++ b/index.html
@@ -3309,37 +3309,36 @@
 						</li>
 					</ol>
 
-				</section>
-
-				<section id="absolute-url-check">
-					<h4>Absolute URL Check</h4>
-
-					<p>To perform an <dfn>absolute URL check</dfn> on <var>data</var>, with a base URL <var>base</var>,
-						run the following steps:</p>
-
-					<ol>
-						<li>
-							<p>if <var>data</var> is a <a href="https://infra.spec.whatwg.org/#string">string</a>, set
+					<section id="absolute-url-check">
+						<h4>Absolute URL Check</h4>
+						
+						<p>To perform an <dfn>absolute URL check</dfn> on <var>data</var>, with a base URL <var>base</var>,
+							run the following steps:</p>
+						
+						<ol>
+							<li>
+								<p>if <var>data</var> is a <a href="https://infra.spec.whatwg.org/#string">string</a>, set
 									<var>data</var> to the result of running the <a
-									href="https://url.spec.whatwg.org/#concept-url-parser">URL parser</a> with
+										href="https://url.spec.whatwg.org/#concept-url-parser">URL parser</a> with
 									<var>data</var> as input and <var>base</var> as the base URL.</p>
-						</li>
-						<li>
-							<p>otherwise, if <var>data</var> is a <a href="https://infra.spec.whatwg.org/#list"
-								>list</a>, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-								<var>item</var> of <var>data</var>, set <var>item</var> to the result of runing
+							</li>
+							<li>
+								<p>otherwise, if <var>data</var> is a <a href="https://infra.spec.whatwg.org/#list"
+									>list</a>, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+									<var>item</var> of <var>data</var>, set <var>item</var> to the result of runing
 									<a>absolute URL check</a>, when successful, given <var>item</var> and
 									<var>base</var>. Otherwise, <a href="https://infra.spec.whatwg.org/#list-remove"
-									>remove</a>
-								<var>item</var> from <var>data</var>.</p>
-						</li>
-						<li>
-							<p>otherwise, <a>validation error</a>, return failure.</p>
-						</li>
-						<li>
-							<p>Return <var>data</var>.</p>
-						</li>
-					</ol>
+										>remove</a>
+									<var>item</var> from <var>data</var>.</p>
+							</li>
+							<li>
+								<p>otherwise, <a>validation error</a>, return failure.</p>
+							</li>
+							<li>
+								<p>Return <var>data</var>.</p>
+							</li>
+						</ol>
+					</section>
 				</section>
 
 				<section id="validate-data">
@@ -3440,217 +3439,217 @@
 							<p>Return <var>data</var>.</p>
 						</li>
 					</ol>
-				</section>
-
-				<section id="common-data-checks">
-					<h4>Common Data Checks</h4>
-
-					<p>To process the <dfn>common data checks</dfn> on a property <var>term</var>'s <var>value</var>,
-						run these steps:</p>
-
-					<ol>
-						<li id="common-checks-value-categories">
-							<p>(<a href="#properties-value-categories"></a>) If <var>term</var> has a known <a
+					
+					<section id="common-data-checks">
+						<h4>Common Data Checks</h4>
+						
+						<p>To process the <dfn>common data checks</dfn> on a property <var>term</var>'s <var>value</var>,
+							run these steps:</p>
+						
+						<ol>
+							<li id="common-checks-value-categories">
+								<p>(<a href="#properties-value-categories"></a>) If <var>term</var> has a known <a
 									href="#properties-value-categories">value category</a>, set <var>value</var> to the
-								result of calling <a>check category type</a>, when successful, given the variables
+									result of calling <a>check category type</a>, when successful, given the variables
 									<var>term</var> and <var>value</var>. Otherwise, return failure.</p>
-						</li>
-						<li id="common-checks-entities">
-							<p>(<a href="#value-entity"></a>) If <var>term</var> expects an <a href="#value-array"
+							</li>
+							<li id="common-checks-entities">
+								<p>(<a href="#value-entity"></a>) If <var>term</var> expects an <a href="#value-array"
 									>array</a> of <a href="#value-entity">entities</a>, <a
-									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-								<var>item</var> of <var>value</var>, check whether <var>item["name"]</var> is set:</p>
-							<ul>
-								<li>
-									<p>If not, <a>validation error</a>, <a
+										href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+									<var>item</var> of <var>value</var>, check whether <var>item["name"]</var> is set:</p>
+								<ul>
+									<li>
+										<p>If not, <a>validation error</a>, <a
 											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-										<var>item</var> from <var>value</var>.</p>
-								</li>
-								<li>If so, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-									<var>name</var> of <var>item["name"]</var>, if <var>name["value"]</var> is not set,
-									or is an empty string, <a href="https://infra.spec.whatwg.org/#list-remove"
-										>remove</a>
-									<var>name</var> from <var>item["name"]</var>.</li>
-							</ul>
-						</li>
-
-						<li id="common-checks-language">
-							<p>(<a href="#manifest-lang-dir-global"></a> and <a href="#manifest-lang-dir-local"></a>) If
+											<var>item</var> from <var>value</var>.</p>
+									</li>
+									<li>If so, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+										<var>name</var> of <var>item["name"]</var>, if <var>name["value"]</var> is not set,
+										or is an empty string, <a href="https://infra.spec.whatwg.org/#list-remove"
+											>remove</a>
+										<var>name</var> from <var>item["name"]</var>.</li>
+								</ul>
+							</li>
+							
+							<li id="common-checks-language">
+								<p>(<a href="#manifest-lang-dir-global"></a> and <a href="#manifest-lang-dir-local"></a>) If
 									<var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
-								>map</a>:</p>
-							<ul>
-								<li>
-									<p>if <var>value["language"]</var> is set and its value is not <a
+										>map</a>:</p>
+								<ul>
+									<li>
+										<p>if <var>value["language"]</var> is set and its value is not <a
 											href="https://tools.ietf.org/html/bcp47#section-2.2.9"
-										>well-formed</a>&#160;[[!bcp47]], <a>validation error</a>, <a
-											href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-										<var>value["language"]</var>.</p>
-									<p>if <var>value["direction"]</var> is set and its value is not one of
+											>well-formed</a>&#160;[[!bcp47]], <a>validation error</a>, <a
+												href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+											<var>value["language"]</var>.</p>
+										<p>if <var>value["direction"]</var> is set and its value is not one of
 											"<code>ltr</code>" or "<code>rtl</code>", <a>validation error</a>, <a
-											href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-										<var>value["direction"]</var>.</p>
-								</li>
-							</ul>
-						</li>
-
-						<li id="common-checks-linkedresource">
-							<p>(<a href="#value-linked-resource"></a>) If <var>term</var> expects an <a
+												href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+											<var>value["direction"]</var>.</p>
+									</li>
+								</ul>
+							</li>
+							
+							<li id="common-checks-linkedresource">
+								<p>(<a href="#value-linked-resource"></a>) If <var>term</var> expects an <a
 									href="#value-array">array</a> of <a href="#LinkedResource-def">LinkedResources</a>,
 									<a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-								<var>resource</var> of <var>value</var>:</p>
-							<ul>
-								<li>
-									<p>if <var>resource["url"]</var> is not set, or its value is an empty string,
+									<var>resource</var> of <var>value</var>:</p>
+								<ul>
+									<li>
+										<p>if <var>resource["url"]</var> is not set, or its value is an empty string,
 											<a>validation error</a>, <a
-											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-										<var>resource</var> from <var>value</var>, then <a
-											href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
-									<p>Otherwise, if <var>resource["url"]</var> is not a valid URL&#160;[[!url]],
+												href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+											<var>resource</var> from <var>value</var>, then <a
+												href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
+										<p>Otherwise, if <var>resource["url"]</var> is not a valid URL&#160;[[!url]],
 											<a>validation error</a>, <a
-											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-										<var>resource</var> from <var>value</var>, then <a
-											href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
-								</li>
-								<li>
-									<p>if <a href="#linkedresource-length"><var>resource["length"]</var></a> is set and
-										is not a number, or is a negative number, <a>validation error</a>, <a
-											href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-										<var>resource["length"]</var>.</p>
-								</li>
-								<li>
-									<p>if <a href="#linkedresource-alternate"><var>resource["alternate"]</var></a> is
-										set, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-										<var>alternate</var> of <var>resource["alterate"]</var>, if
+												href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+											<var>resource</var> from <var>value</var>, then <a
+												href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
+									</li>
+									<li>
+										<p>if <a href="#linkedresource-length"><var>resource["length"]</var></a> is set and
+											is not a number, or is a negative number, <a>validation error</a>, <a
+												href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+											<var>resource["length"]</var>.</p>
+									</li>
+									<li>
+										<p>if <a href="#linkedresource-alternate"><var>resource["alternate"]</var></a> is
+											set, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+											<var>alternate</var> of <var>resource["alterate"]</var>, if
 											<var>alternate["encodingFormat"]</var> is not set, <a>validation
-										error</a>.</p>
-								</li>
-							</ul>
-						</li>
-
-						<li id="common-checks-recurse-maps">
-							<p>If <var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
+												error</a>.</p>
+									</li>
+								</ul>
+							</li>
+							
+							<li id="common-checks-recurse-maps">
+								<p>If <var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
 									href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
-								<var>key</var> → <var>keyValue</var> of <var>value</var>, set <var>value[key]</var> to
-								the result of running <a>common data checks</a> given <var>key</var> and
+									<var>key</var> → <var>keyValue</var> of <var>value</var>, set <var>value[key]</var> to
+									the result of running <a>common data checks</a> given <var>key</var> and
 									<var>keyValue</var>.</p>
-						</li>
-
-						<li id="common-checks-recurse-lists">
-							<p>If <var>value</var> is a <a href="https://infra.spec.whatwg.org/#list">list</a>, <a
+							</li>
+							
+							<li id="common-checks-recurse-lists">
+								<p>If <var>value</var> is a <a href="https://infra.spec.whatwg.org/#list">list</a>, <a
 									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-								<var>item</var> of <var>value</var>, if <var>item</var> is a <a
-									href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
-									href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
-								<var>key</var> → <var>keyValue</var> of <var>value</var>, set <var>value[key]</var> to
-								the result of running <a>common data checks</a> given <var>key</var> and
+									<var>item</var> of <var>value</var>, if <var>item</var> is a <a
+										href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
+											href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+									<var>key</var> → <var>keyValue</var> of <var>value</var>, set <var>value[key]</var> to
+									the result of running <a>common data checks</a> given <var>key</var> and
 									<var>keyValue</var>.</p>
-						</li>
-
-						<li id="common-check-end">
-							<p>Return <var>value</var>.</p>
-						</li>
-					</ol>
-				</section>
-
-				<section id="category-check">
-					<h4>Value Category Check</h4>
-
-					<p>To <dfn>check category type</dfn> of a property <var>term</var>'s <var>value</var>, run these
-						steps:</p>
-
-					<ol>
-						<li>
-							<p>If <var>term</var> expects an <a href="#value-array">array</a>:</p>
-							<ol>
-								<li>
-									<p>if <var>value</var> is not a <a href="https://infra.spec.whatwg.org/#list"
+							</li>
+							
+							<li id="common-check-end">
+								<p>Return <var>value</var>.</p>
+							</li>
+						</ol>
+					</section>
+					
+					<section id="category-check">
+						<h4>Check Category Type</h4>
+						
+						<p>To <dfn>check category type</dfn> of a property <var>term</var>'s <var>value</var>, run these
+							steps:</p>
+						
+						<ol>
+							<li>
+								<p>If <var>term</var> expects an <a href="#value-array">array</a>:</p>
+								<ol>
+									<li>
+										<p>if <var>value</var> is not a <a href="https://infra.spec.whatwg.org/#list"
 											>list</a>, <a>validation error</a>, return failure.</p>
-								</li>
-								<li>
-									<p>otherwise, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-										<var>item</var> of <var>value</var>:</p>
-									<ol>
-										<li>
-											<p>if <var>item</var> does not match the expected type of the array,
+									</li>
+									<li>
+										<p>otherwise, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+											<var>item</var> of <var>value</var>:</p>
+										<ol>
+											<li>
+												<p>if <var>item</var> does not match the expected type of the array,
 													<a>validation error</a>, <a
-													href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-												<var>item</var> from <var>value</var>, then <a
-													href="https://infra.spec.whatwg.org/#iteration-continue"
-													>continue</a>.</p>
-										</li>
-										<li>
-											<p>if <var>item</var> is a <a
+														href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+													<var>item</var> from <var>value</var>, then <a
+														href="https://infra.spec.whatwg.org/#iteration-continue"
+														>continue</a>.</p>
+											</li>
+											<li>
+												<p>if <var>item</var> is a <a
 													href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
-													href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
-												<var>key</var> → <var>keyValue</var> of <var>item</var>, if
+														href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+													<var>key</var> → <var>keyValue</var> of <var>item</var>, if
 													<var>key</var> has an expected type, set <var>key</var> to the
-												result of running <a>check category type</a> given the variables
+													result of running <a>check category type</a> given the variables
 													<var>key</var> and <var>keyValue</var>. If the result of processing
 													<var>item</var> is an empty <a
-													href="https://infra.spec.whatwg.org/#ordered-map">map</a>,
+														href="https://infra.spec.whatwg.org/#ordered-map">map</a>,
 													<a>validation error</a>, <a
-													href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-												<var>item</var> from <var>value</var>.</p>
-										</li>
-									</ol>
-									<p>If the result of processing <var>value</var> is an empty <a href="#value-array"
+														href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+													<var>item</var> from <var>value</var>.</p>
+											</li>
+										</ol>
+										<p>If the result of processing <var>value</var> is an empty <a href="#value-array"
 											>array</a>, <a>validation error</a>, return failure.</p>
-								</li>
-							</ol>
-						</li>
-						<li>
-							<p>Otherwise, if <var>term</var> expects a <a
+									</li>
+								</ol>
+							</li>
+							<li>
+								<p>Otherwise, if <var>term</var> expects a <a
 									href="https://infra.spec.whatwg.org/#ordered-map">map</a>:</p>
-							<ol>
-								<li>
-									<p>if <var>value</var> is not a <a href="https://infra.spec.whatwg.org/#ordered-map"
+								<ol>
+									<li>
+										<p>if <var>value</var> is not a <a href="https://infra.spec.whatwg.org/#ordered-map"
 											>map</a>, <a>validation error</a>, return failure.</p>
-								</li>
-								<li>
-									<p>otherwise, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
-										<var>key</var> → <var>keyValue</var> of <var>value</var>, if <var>key</var> has
-										an expected type, set <var>key</var> to the result of running <a>check category
-											type</a> given <var>key</var> and <var>keyValue</var>. If the result of
-										processing <var>value</var> is an empty <a
-											href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>validation
-											error</a>, return failure.</p>
-								</li>
-							</ol>
-						</li>
-						<li>
-							<p>Otherwise, if <var>value</var> does not have the expected type of <var>term</var>,
+									</li>
+									<li>
+										<p>otherwise, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+											<var>key</var> → <var>keyValue</var> of <var>value</var>, if <var>key</var> has
+											an expected type, set <var>key</var> to the result of running <a>check category
+												type</a> given <var>key</var> and <var>keyValue</var>. If the result of
+											processing <var>value</var> is an empty <a
+												href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>validation
+													error</a>, return failure.</p>
+									</li>
+								</ol>
+							</li>
+							<li>
+								<p>Otherwise, if <var>value</var> does not have the expected type of <var>term</var>,
 									<a>validation error</a>, return failure.</p>
-						</li>
-						<li>
-							<p>Return <var>value</var>.</p>
-						</li>
-					</ol>
-				</section>
-
-				<section id="remove-empty-arrays">
-					<h4>Remove Empty Arrays</h4>
-
-					<p>To <dfn>remove empty arrays</dfn> from a property <var>term</var>'s <var>value</var>, run these
-						steps:</p>
-
-					<ol>
-						<li>
-							<p>If <var>value</var> is an empty <a href="https://infra.spec.whatwg.org/#list">list</a>,
-								return failure.</p>
-						</li>
-						<li>
-							<p>Otherwise, if <var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
+							</li>
+							<li>
+								<p>Return <var>value</var>.</p>
+							</li>
+						</ol>
+					</section>
+					
+					<section id="remove-empty-arrays">
+						<h4>Remove Empty Arrays</h4>
+						
+						<p>To <dfn>remove empty arrays</dfn> from a property <var>term</var>'s <var>value</var>, run these
+							steps:</p>
+						
+						<ol>
+							<li>
+								<p>If <var>value</var> is an empty <a href="https://infra.spec.whatwg.org/#list">list</a>,
+									return failure.</p>
+							</li>
+							<li>
+								<p>Otherwise, if <var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
 									>map</a>, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
-								<var>key</var> → <var>keyValue</var> of <var>value</var>, if running <a>remove empty
-									arrays</a> given <var>key</var> and <var>keyValue</var> returns failure, <a
-									href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-								<var>value[key]</var>.</p>
-						</li>
-					</ol>
+									<var>key</var> → <var>keyValue</var> of <var>value</var>, if running <a>remove empty
+										arrays</a> given <var>key</var> and <var>keyValue</var> returns failure, <a
+											href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+									<var>value[key]</var>.</p>
+							</li>
+						</ol>
+					</section>
 				</section>
 
 				<section id="add-html-defaults">
-					<h3>Add HTML Default Values</h3>
+					<h3>Add HTML Defaults</h3>
 
 					<p>To <dfn>add HTML defaults</dfn> for missing properties in <a
 							href="https://infra.spec.whatwg.org/#ordered-map">map</a>

--- a/index.html
+++ b/index.html
@@ -3033,6 +3033,17 @@
 							</details>
 						</li>
 
+						<li id="normalize-context">
+							<p>(<a href="#publication-context"></a>) If <var>term</var> is <var>@context</var>, return
+								failure.</p>
+							<details>
+								<summary>Explanation</summary>
+								<p><var>@context</var> provides information for the initial processing of the manifest,
+									but is not retained in the internal data representation. Returning a failure signals
+									to remove the term.</p>
+							</details>
+						</li>
+
 						<li id="normalize-arrays">
 							<p>(<a href="#value-array"></a>) If, depending on <var>context</var>, <var>term</var>
 								expects an <a href="#value-array">array</a> and <var>value</var> is a <a
@@ -3077,10 +3088,11 @@
 ]»</pre>
 								</li>
 								<li>
-									<p>otherwise, if <var>entity</var> is number, <a
-											href="https://infra.spec.whatwg.org/#boolean">boolean</a> or <a
-											href="https://infra.spec.whatwg.org/#nulls">null</a>, <a>validation
-											error</a>, <a href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+									<p>otherwise, if <var>entity</var> is <a href="https://infra.spec.whatwg.org/#list"
+											>list</a>, number, <a href="https://infra.spec.whatwg.org/#boolean"
+											>boolean</a> or <a href="https://infra.spec.whatwg.org/#nulls">null</a>,
+											<a>validation error</a>, <a
+											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 										<var>entity</var> from <var>normalized</var>.</p>
 								</li>
 							</ol>
@@ -3345,10 +3357,11 @@
 										<var>item</var> of <var>normalized</var> that is a <a
 											href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
 											href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
-										<var>key</var> → <var>keyValue</var> of <var>normalized</var>, set
-											<var>key</var> to the result of running <a href="#processing-normalize"
-											>normalize data</a> given <var>key</var>, <var>keyValue</var>,
-											<var>lang</var>, <var>dir</var>, <var>base</var> and <var>context</var>.</p>
+										<var>key</var> → <var>keyValue</var> of <var>item</var>, set <var>key</var> to
+										the result of running <a href="#processing-normalize">normalize data</a> given
+											<var>key</var>, <var>keyValue</var>, <var>lang</var>, <var>dir</var>,
+											<var>base</var> and using <var>key</var> as the context. If failure is
+										returned, remove <var>key</var> from <var>item</var>.</p>
 								</li>
 								<li>
 									<p>if <var>normalized</var> is a <a
@@ -3357,7 +3370,9 @@
 										<var>key</var> → <var>keyValue</var> of <var>normalized</var>, set
 											<var>key</var> to the result of running <a href="#processing-normalize"
 											>normalize data</a> given <var>key</var>, <var>keyValue</var>,
-											<var>lang</var>, <var>dir</var>, <var>base</var> and <var>context</var>.</p>
+											<var>lang</var>, <var>dir</var>, <var>base</var> and using <var>key</var> as
+										the context. If failure is returned, remove <var>key</var> from
+											<var>normalized</var>.</p>
 								</li>
 							</ol>
 							<details>
@@ -3366,6 +3381,7 @@
 									recursively checks <var>normalized</var> for additional map entries to process. If
 										<var>normalized</var> is a list, each item is inspected to determine if it is a
 									map that can be processed.</p>
+								<p>If a failure is returned, the item is removed from the map.</p>
 							</details>
 						</li>
 
@@ -3427,7 +3443,7 @@
 							<p><a href="https://infra.spec.whatwg.org/#map-iterate">For each</a>
 								<var>term</var> → <var>value</var> of <var>data</var>, set <var>term</var> to the result
 								of running the <a>global data checks</a>, when successful, given <var>term</var> and
-									<var>value</var>, and using <var>term</var> as the context. If a failure occurs,
+									<var>value</var>, and using <var>term</var> as the context. If failure is returned,
 								remove <var>data[term]</var>.</p>
 							<details>
 								<summary>Explanation</summary>

--- a/index.html
+++ b/index.html
@@ -2959,13 +2959,13 @@
 						<p>Set <var>processed</var> to the result of running <a>data validation</a> given
 								<var>processed</var>.</p>
 					</li>
-					
+
 					<li id="processing-defaults">
 						<p>Set <var>processed</var> to the result of running <a>add HTML defaults</a>, when successful,
 							given <var>processed</var> and <var>document</var>. Otherwise, terminate processing, return
 							failure.</p>
 					</li>
-					
+
 					<li id="processing-end">
 						<p>Return <var>processed</var>.</p>
 					</li>
@@ -3421,21 +3421,21 @@
 							<p>If a <a>profile</a> specifies data validation checks, those steps are executed at this
 								point.</p>
 						</li>
-						
+
 						<li id="processing-remove-empty-arrays">
 							<p><a href="https://infra.spec.whatwg.org/#map-iterate">For each</a>
 								<var>term</var> → <var>value</var> of <var>data</var>, if running <a>remove empty
-									arrays</a> given the variables <var>term</var> and <var>value</var> returns failure, <a
-										href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+									arrays</a> given the variables <var>term</var> and <var>value</var> returns failure,
+									<a href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 								<var>data["term"]</var>.</p>
 							<details>
 								<summary>Explanation</summary>
-								<p>As the processing of the manifest involves removing invalid values at various stages, the
-									final data structure might end up with some lists that not no longer contain any values.
-									This step iterates back over the data and removes any such empty lists.</p>
+								<p>As the processing of the manifest involves removing invalid values at various stages,
+									the final data structure might end up with some lists that not no longer contain any
+									values. This step iterates back over the data and removes any such empty lists.</p>
 							</details>
 						</li>
-						
+
 						<li id="validate-end">
 							<p>Return <var>data</var>.</p>
 						</li>
@@ -3452,8 +3452,8 @@
 						<li id="common-checks-value-categories">
 							<p>(<a href="#properties-value-categories"></a>) If <var>term</var> has a known <a
 									href="#properties-value-categories">value category</a>, set <var>value</var> to the
-								result of calling <a href="#category-check">value category check</a>, when successful,
-								given the variables <var>term</var> and <var>value</var>. Otherwise, return failure.</p>
+								result of calling <a>check category type</a>, when successful, given the variables
+									<var>term</var> and <var>value</var>. Otherwise, return failure.</p>
 						</li>
 						<li id="common-checks-entities">
 							<p>(<a href="#value-entity"></a>) If <var>term</var> expects an <a href="#value-array"
@@ -3555,7 +3555,7 @@
 				<section id="category-check">
 					<h4>Value Category Check</h4>
 
-					<p>To <dfn>check the category</dfn> of a property <var>term</var>'s <var>value</var>, run these
+					<p>To <dfn>check category type</dfn> of a property <var>term</var>'s <var>value</var>, run these
 						steps:</p>
 
 					<ol>
@@ -3584,9 +3584,9 @@
 													href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
 												<var>key</var> → <var>keyValue</var> of <var>item</var>, if
 													<var>key</var> has an expected type, set <var>key</var> to the
-												result of running <a href="#category-check">check category type</a>
-												given the variables <var>key</var> and <var>keyValue</var>. If the
-												result of processing <var>item</var> is an empty <a
+												result of running <a>check category type</a> given the variables
+													<var>key</var> and <var>keyValue</var>. If the result of processing
+													<var>item</var> is an empty <a
 													href="https://infra.spec.whatwg.org/#ordered-map">map</a>,
 													<a>validation error</a>, <a
 													href="https://infra.spec.whatwg.org/#list-remove">remove</a>
@@ -3609,11 +3609,11 @@
 								<li>
 									<p>otherwise, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
 										<var>key</var> → <var>keyValue</var> of <var>value</var>, if <var>key</var> has
-										an expected type, set <var>key</var> to the result of running <a
-											href="#category-check">check category type</a> given <var>key</var> and
-											<var>keyValue</var>. If the result of processing <var>value</var> is an
-										empty <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>,
-											<a>validation error</a>, return failure.</p>
+										an expected type, set <var>key</var> to the result of running <a>check category
+											type</a> given <var>key</var> and <var>keyValue</var>. If the result of
+										processing <var>value</var> is an empty <a
+											href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>validation
+											error</a>, return failure.</p>
 								</li>
 							</ol>
 						</li>
@@ -3648,14 +3648,14 @@
 						</li>
 					</ol>
 				</section>
-				
+
 				<section id="add-html-defaults">
 					<h3>Add HTML Default Values</h3>
-					
+
 					<p>To <dfn>add HTML defaults</dfn> for missing properties in <a
-						href="https://infra.spec.whatwg.org/#ordered-map">map</a>
+							href="https://infra.spec.whatwg.org/#ordered-map">map</a>
 						<var>data</var> with a HTML document node <var>document</var>, run the following steps:</p>
-					
+
 					<ol>
 						<li id="processing-defaults-title">
 							<p>(<a href="#pub-title"></a>) If <var>data["name"]</var> is not set, or its value is an
@@ -3663,25 +3663,25 @@
 							<ul>
 								<li>
 									<p>Let <var>title</var> be an empty <a
-										href="https://infra.spec.whatwg.org/#ordered-map">map</a>. Set its values as
+											href="https://infra.spec.whatwg.org/#ordered-map">map</a>. Set its values as
 										follows:</p>
 									<ul>
 										<li>
 											<p>if the <a data-cite="html#the-title-element"><code>title</code></a>
 												element&#160;[[!html]] of <var>document</var> is set and its contains is
 												not empty, set <var>title["value"]</var> to the text content of the
-												<code>title</code> element.</p>
+													<code>title</code> element.</p>
 											<p>Set <var>title["language"]</var> to the <a
-												data-cite="html#the-lang-and-xml:lang-attributes"
+													data-cite="html#the-lang-and-xml:lang-attributes"
 												>language</a>&#160;[[!html]], if available, and
-												<var>title["direction"]</var> to the <a
+													<var>title["direction"]</var> to the <a
 													data-cite="html#the-dir-attribute">base direction</a>&#160;[[!html]]
 												if that value is available and its value is either "<code>ltr</code>" or
-												"<code>rtl</code>". </p>
+													"<code>rtl</code>". </p>
 										</li>
 										<li>
 											<p>otherwise, <a>validation error</a>, generate a value for
-												<var>title["value"]</var> (see the <a href="#generate_title"
+													<var>title["value"]</var> (see the <a href="#generate_title"
 													>separate note for details</a>). Set <var>title["language"]</var>
 												and <var>title["direction"]</var> as approrpriate for the generated
 												title.</p>
@@ -3718,7 +3718,7 @@
 }</pre>
 							</details>
 						</li>
-						
+
 						<li id="processing-defaults-reading-order">
 							<p>(<a href="#default-reading-order"></a>) If <var>data["readingOrder"]</var> is not set or
 								its value is an empty <a href="https://infra.spec.whatwg.org/#string">string</a> or <a
@@ -3730,9 +3730,9 @@
 								</li>
 								<li>
 									<p>otherwise, set <var>data["readingOrder"]</var> to an empty <a
-										href="https://infra.spec.whatwg.org/#list">list</a> and <a
+											href="https://infra.spec.whatwg.org/#list">list</a> and <a
 											href="https://infra.spec.whatwg.org/#list-append">append</a> the <a
-												href="https://infra.spec.whatwg.org/#ordered-map">map</a>
+											href="https://infra.spec.whatwg.org/#ordered-map">map</a>
 										<code>«[&#160;"url" → <a data-cite="!dom#concept-document-url"
 											>document.URL</a>&#160;]»</code>.</p>
 								</li>
@@ -3744,12 +3744,12 @@
 									resource. </p>
 							</details>
 						</li>
-						
+
 						<li id="processing-defaults-extension">
 							<p>If a <a>profile</a> specifies <var>document</var> fallbacks, those steps are executed at
 								this point.</p>
 						</li>
-						
+
 						<li>
 							<p>Return <var>data</var>.</p>
 						</li>

--- a/index.html
+++ b/index.html
@@ -214,10 +214,9 @@
 
 					<p>The <a>manifest</a> also identifies key resources of a digital publication through the use of
 						link relations. These relations are applied to the <a href="#linkedresource-rel"
-								><code>rel</code> property</a> of <a href="#LinkedResource-def"
-								><code>LinkedResource</code> objects</a> (e.g., the links found in the <a
-							href="#pub-table-of-contents">table of contents</a> and <a href="#resource-list">resource
-							list</a>).</p>
+								><code>rel</code> property</a> of <a><code>LinkedResource</code></a> objects (e.g., the
+						links found in the <a href="#pub-table-of-contents">table of contents</a> and <a
+							href="#resource-list">resource list</a>).</p>
 
 					<p>The types of resources these relations identify are categorized as follows:</p>
 
@@ -374,15 +373,15 @@
 						<ul>
 							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a> value;
 								or</li>
-							<li>A <code>LocalizableString</code>.</li>
+							<li>A <a><code>LocalizableString</code></a>.</li>
 						</ul>
 
 						<p>A single string value represents an implied object whose <code>value</code> property is the
 							string's text and whose language is determined from other information in the manifest.</p>
 
-						<p>A <code>LocalizableString</code> is a [[!json]]&#160;<a
-								href="https://tools.ietf.org/html/rfc4627#section-2.2">object</a> consisting of the
-							following properties:</p>
+						<p>A <dfn data-lt="LocalizableStrings|localizable string"><code>LocalizableString</code></dfn>
+							is a [[!json]]&#160;<a href="https://tools.ietf.org/html/rfc4627#section-2.2">object</a>
+							consisting of the following properties:</p>
 
 						<table class="zebra">
 							<thead>
@@ -476,15 +475,15 @@
 						<ul>
 							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a> value;
 								or</li>
-							<li>an <code>Entity</code>.</li>
+							<li>an <a><code>Entity</code></a>.</li>
 						</ul>
 
 						<p>A single string value represents an instance of an <code>Entity</code> object whose
 								<code>name</code> property is the string's text and whose <code>type</code> is assumed
 							to be <a href="https://schema.org/Person">Person</a>&#160;[[!schema.org]].</p>
 
-						<p>An <code>Entity</code> is defined as an instance of either the [[!schema.org]] <a
-								href="https://schema.org/Person"><code>Person</code></a> or <a
+						<p>An <dfn data-lt="Entities">Entity</dfn> is defined as an instance of either the
+							[[!schema.org]] <a href="https://schema.org/Person"><code>Person</code></a> or <a
 								href="https://schema.org/Organization"><code>Organization</code></a> type with the
 							following minimal property set:</p>
 
@@ -604,13 +603,14 @@
 						<ol>
 							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
 								encoding the <a>URL</a> of the resources; or</li>
-							<li>an instance of a <a href="LinkedResource-def"><code>LinkedResource</code></a>.</li>
+							<li>an instance of a <a><code>LinkedResource</code></a>.</li>
 						</ol>
 
 						<p>A string value represents an implied <code>LinkedResource</code> object whose
 								<code>url</code> property is set to the string value.</p>
 
-						<p id="LinkedResource-def">A <code>LinkedResource</code> object is defined as follows:</p>
+						<p>A <dfn data-lt="LinkedResources|linked resources"><code>LinkedResource</code></dfn> object is
+							defined as follows:</p>
 
 						<table class="zebra">
 							<thead>
@@ -1050,7 +1050,7 @@
 					<h4>Item-Specific Declarations</h4>
 
 					<p>It is possible to set the language or a base direction locally for any natural language value in
-						the manifest using a <a href="#LocalizableString">localizable string</a>:</p>
+						the manifest using a <a>localizable string</a>:</p>
 
 
 					<aside class="example" title="Providing the author name in English for a Chinese publication.">
@@ -2111,8 +2111,7 @@
 									</td>
 									<td>Order of progression through the resources of a digital publication.</td>
 									<td>
-										<p>One or more <a href="#LinkedResource-def"
-											><code>LinkedResource</code></a>.</p>
+										<p>One or more <a><code>LinkedResource</code></a>.</p>
 									</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-linked-resource">Linked
@@ -2128,8 +2127,7 @@
 						<ul>
 							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
 								representing the <a>URL</a> of the resource; or</li>
-							<li>an instance of a <a href="#LinkedResource-def"><code>LinkedResource</code></a>
-								object.</li>
+							<li>an instance of a <a><code>LinkedResource</code></a> object.</li>
 						</ul>
 
 						<p>A single string value represents an instance of a <code>LinkedResource</code> object whose
@@ -2201,8 +2199,7 @@
 									<td>List of additional publication resources used in the processing or rendering of
 										a publication.</td>
 									<td>
-										<p>One or more <a href="#LinkedResource-def"
-											><code>LinkedResource</code></a>.</p>
+										<p>One or more <a><code>LinkedResource</code></a>.</p>
 									</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-linked-resource">Linked
@@ -2218,8 +2215,7 @@
 						<ul>
 							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
 								representing the <a>URL</a> of the resource; or</li>
-							<li>an instance of a <a href="#LinkedResource-def"><code>LinkedResource</code></a>
-								object.</li>
+							<li>an instance of a <a><code>LinkedResource</code></a> object.</li>
 						</ul>
 
 						<p>A single string value represents an instance of a <code>LinkedResource</code> object whose
@@ -2291,8 +2287,7 @@
 									<td>List of resources associated with a publication but not required for its
 										processing or rendering.</td>
 									<td>
-										<p>One or more <a href="#LinkedResource-def"
-											><code>LinkedResource</code></a>.</p>
+										<p>One or more <a><code>LinkedResource</code></a>.</p>
 									</td>
 									<td>
 										<a href="#value-array">Array</a> of <a href="#value-linked-resource">Linked
@@ -2308,8 +2303,7 @@
 						<ul>
 							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
 								representing the <a>URL</a> of the resource; or</li>
-							<li>an instance of a <a href="#LinkedResource-def"><code>LinkedResource</code></a>
-								object.</li>
+							<li>an instance of a <a><code>LinkedResource</code></a> object.</li>
 						</ul>
 
 						<p>A single string value represents an instance of a <code>LinkedResource</code> object whose
@@ -2378,8 +2372,8 @@
 						<h4>Linked records</h4>
 
 						<p>Extending the manifest through links to a record, such as an ONIX&#160;[[onix]] or
-							BibTeX&#160;[[bibtex]] file, MUST be expressed using a <a href="#LinkedResource-def"
-									><code>LinkedResource</code></a> object, where:</p>
+							BibTeX&#160;[[bibtex]] file, MUST be expressed using a <a><code>LinkedResource</code></a>
+							object, where:</p>
 						<ul>
 							<li>the <a href="#linkedresource-rel"><code>rel</code> property</a> of the
 									<code>LinkedResource</code> SHOULD include a relevant identifier defined by IANA or
@@ -2848,20 +2842,35 @@
 				<p class="note">This algorithm does not define how the manifest is discovered and obtained. The steps by
 					which to do so are defined by each <a>digital publication</a> format.</p>
 
-				<p class="note">For illustrative purposes, the examples in this section show the structure of internal
-					representation as JavaScript objects. See also <a href="#internal-rep-data-model"></a> for a
-					visualization of the resulting structure.</p>
+				<p>Some steps in this algorithm depend on the expected value category of a term, so the context in which
+					a term is used can affect processing (e.g., a <a href="#address"><code>url</code></a> expects an <a
+						href="#value-array">Array</a> (of URLs) only when the direct property of the Publication
+					Manifest). To differentiate these uses a <dfn>context</dfn> is provided to certain function calls.
+					This context is set to the term that initiates the processing call, allowing the different contexts
+					to be determined.</p>
 
 				<p>To <dfn data-lt="processing algorithm|processing the manifest|processing a manifest">process a
 						manifest</dfn>, run the following steps:</p>
 
 				<ol>
+					<li id="processing-create-processed">
+						<p>Let <var>processed</var> be an empty <a href="https://infra.spec.whatwg.org/#ordered-map"
+								>map</a> that will contain the <a href="#dfn-internal-representation">internal
+								representation</a> of the manifest.</p>
+					</li>
+
 					<li id="processing-json-infra">
 						<p>Let <var>manifest</var> be the result of parsing <a
 								href="https://infra.spec.whatwg.org/#parse-json-into-infra-values">JSON into Infra
 								values</a> given <var>text</var>. If <var>manifest</var> is not a <a
 								href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>fatal error</a>, return
 							failure.</p>
+						<details>
+							<summary>Explanation</summary>
+							<p>Publication manifests have to be expressed as JSON objects, not arrays. After converting
+								the manifest to [[infra]] types, an additional check is made that the resulting
+								structure is a <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>.</p>
+						</details>
 					</li>
 
 					<li id="processing-context">
@@ -2872,22 +2881,28 @@
 								href="https://infra.spec.whatwg.org/#string">string</a> values
 								"<code>https://schema.org</code>" and "<code>https://www.w3.org/ns/pub-context</code>",
 							in this order, <a>fatal error</a>, return failure.</p>
+						<details>
+							<summary>Explanation</summary>
+							<p>If the context URLs are not set as expected, the JSON data does not represent a
+								publication manifest.</p>
+						</details>
 					</li>
 
 					<li id="processing-conformance">
-						<p>(<a href="#profile-conformance"></a>) Let <var>profile</var> be the <a>profile</a> the
-							manifest conforms to. Set <var>profile</var> as follows:</p>
+						<p>(<a href="#profile-conformance"></a>) Let <var>processed["profile"]</var> be the
+								<a>profile</a> the manifest conforms to. Set <var>processed["profile"]</var> as
+							follows:</p>
 						<ol>
 							<li>
 								<p>If <var>manifest["conformsTo"]</var> is not set, or does not include a profile the
 									user agent recognizes as capable of processing and/or rendering, the user agent
 									SHOULD inspect the media type(s) of the resources in the reading order to determine
 									if the publication matches a profile it is capable of processing or rendering. If
-									so, <a>validation error</a>, set <var>profile</var> to the matching profile.
-									Otherwise, <a>fatal error</a>, return failure.</p>
+									so, <a>validation error</a>, set <var>processed["profile"]</var> to the matching
+									profile. Otherwise, <a>fatal error</a>, return failure.</p>
 							</li>
 							<li>
-								<p>Otherwise, set <var>profile</var> to the first URL in
+								<p>Otherwise, set <var>processed["profile"]</var> to the first URL in
 										<var>manifest["conformsTo"]</var> the user agent is capable of processing and/or
 									rendering.</p>
 							</li>
@@ -2900,6 +2915,9 @@
 							<p>The profile the publication conforms to determines any additional extension steps that
 								have to be performed during processing. These steps are defined by their respective
 								specifications.</p>
+							<p>The new term <var>profile</var> is created because <var>conformsTo</var> is not
+								restricted to profile identifiers (i.e., the new term provides a persistent identifier
+								of the profile within the internal representation).</p>
 						</details>
 					</li>
 
@@ -2938,32 +2956,48 @@
 							<summary>Explanation</summary>
 							<p>The global language and direction declarations obtained here are used to set the language
 								and base direction, respectively, for localizable strings without a declaration.</p>
+							<p>The iterator moves backwards through <var>@context</var> as the last language and
+								direction declarations override any earlier ones.</p>
 						</details>
-					</li>
-
-					<li id="processing-create-processed">
-						<p>Let <var>processed</var> be an empty <a href="https://infra.spec.whatwg.org/#ordered-map"
-								>map</a> that will contain the <a href="#dfn-internal-representation">internal
-								representation</a> of the manifest.</p>
 					</li>
 
 					<li id="processing-normalize">
 						<p><a href="https://infra.spec.whatwg.org/#map-iterate">For each</a>
 							<var>term</var> → <var>value</var> of <var>manifest</var>, set <var>processed[term]</var> to
 							the result, when successful, of calling <a>normalize data</a> given <var>term</var>,
-								<var>value</var>, <var>lang</var>, <var>dir</var> and <var>base</var>. If failure is
-							returned, do not add <var>term</var> to <var>processed</var>.</p>
+								<var>value</var>, <var>lang</var>, <var>dir</var> and <var>base</var>, and using
+								<var>term</var> as the context. If failure is returned, do not add <var>term</var> to
+								<var>processed</var>.</p>
+						<details>
+							<summary>Explanation</summary>
+							<p>The data normalization steps standardize the incoming manifest data to remove any
+								authoring conveniences, such as the ability to use strings where objects or arrays are
+								expected. The resulting processed data are added to the <var>processed</var> variable
+								and are operated on in subsequent steps.</p>
+						</details>
 					</li>
 
 					<li id="processing-checks">
 						<p>Set <var>processed</var> to the result of running <a>data validation</a> given
 								<var>processed</var>.</p>
+						<details>
+							<summary>Explanation</summary>
+							<p>The data validation checks ensure that the incoming data matches its expected value
+								categories. Any restrictions on the expected values are also enforced at this step, and
+								any invalid data is removed from the final representation.</p>
+						</details>
 					</li>
 
 					<li id="processing-defaults">
 						<p>Set <var>processed</var> to the result of running <a>add HTML defaults</a>, when successful,
 							given <var>processed</var> and <var>document</var>. Otherwise, terminate processing, return
 							failure.</p>
+						<details>
+							<summary>Explanation</summary>
+							<p>The final step is to check if any information missing from the manifest can be obtained
+								from the HTML document that links to the manifest (e.g., the title and reading
+								order).</p>
+						</details>
 					</li>
 
 					<li id="processing-end">
@@ -2971,33 +3005,37 @@
 					</li>
 				</ol>
 
-				<section id="normalize-data">
-					<h4>Data Normalization</h4>
+				<p class="note">For a visualization of the resulting structure, see <a href="#internal-rep-data-model"
+					></a>.</p>
 
-					<p class="note">The following steps depend on the expected value category of a term. Exercise
-						caution when processing terms as value categories depend not only on the name of the term, but
-						also on the object it is used with. For example, the value category for the term <a
-							href="#address"><code>url</code></a> is an <a href="#value-array">Array</a> (of URLs) when
-						the direct property of the Publication Manifest, but a single URL literal when used in other
-						objects.</p>
+				<section id="normalize-data">
+					<h4>Normalize Data</h4>
 
 					<p>To <dfn>normalize data</dfn> for a property <var>term</var>'s <var>value</var>, with the <a
 							href="#manifest-lang-dir-global">global language</a>
 						<var>lang</var>, <a href="#manifest-lang-dir-global">global direction</a>
-						<var>dir</var> and <a>base URL</a>
-						<var>base</var>, run these steps:</p>
+						<var>dir</var>, <a>base URL</a>
+						<var>base</var>, and <a>context</a>
+						<var>context</var> run these steps:</p>
 
 					<ol>
 						<li id="normalize-init">
 							<p>Let <var>normalized</var> be the value of <var>value</var>.</p>
+							<details>
+								<summary>Explanation</summary>
+								<p>The data normalization steps are performed on the copy of the incoming value held in
+									the <var>normalized</var> variable defined in this step. This variable is returned
+									at the end of a successful normalization process.</p>
+							</details>
 						</li>
 
 						<li id="normalize-arrays">
-							<p>(<a href="#value-array"></a>) If <var>term</var> expects an <a href="#value-array"
-									>array</a> and <var>value</var> is a <a href="https://infra.spec.whatwg.org/#string"
-									>string</a>, <a href="https://infra.spec.whatwg.org/#boolean">boolean</a>, number,
-								null, or <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>, set
-									<var>normalized</var> to «&#160;<var>value</var>&#160;».</p>
+							<p>(<a href="#value-array"></a>) If, depending on <var>context</var>, <var>term</var>
+								expects an <a href="#value-array">array</a> and <var>value</var> is a <a
+									href="https://infra.spec.whatwg.org/#string">string</a>, <a
+									href="https://infra.spec.whatwg.org/#boolean">boolean</a>, number, null, or <a
+									href="https://infra.spec.whatwg.org/#ordered-map">map</a>, set <var>normalized</var>
+								to «&#160;<var>value</var>&#160;».</p>
 							<details>
 								<summary>Explanation</summary>
 								<p>A number of terms require their values to be arrays, but, for the sake of
@@ -3010,12 +3048,12 @@
     …
 }</pre>
 								<p>yields:</p>
-								<pre class="example">{
+								<pre class="example">«[
     …
-    "name"   : ["Et dukkehjem"],
-    "author" : ["Henrik Ibsen"],
+    "name"   → « "Et dukkehjem" »,
+    "author" → « "Henrik Ibsen" »,
     …
-}</pre>
+]»</pre>
 							</details>
 						</li>
 
@@ -3044,26 +3082,26 @@
 							</ol>
 							<details>
 								<summary>Explanation</summary>
-								<p>Authors, editors, etc., are expected to be explicitly designed as an object of type
-										<code>Person</code>, but, for the sake of convenience, only their name has to be
-									specified. For example:</p>
+								<p>Creators (authors, editors, etc.), are expected to be explicitly defined as an
+									object, but, for the sake of convenience, only their name has to be specified in the
+									manifest. For example:</p>
 								<pre class="example">{
     …
-    "author" : ["Ralph Ellison"],
+    "author": "Ralph Ellison",
     …
 }</pre>
-								<p>This rule converts the string values to objects, yielding the following for the
-									preceding example:</p>
-								<pre class="example">{
+								<p>This rule converts such string values to maps with a default type of
+										<code>Person</code>, yielding the following for the preceding example:</p>
+								<pre class="example">«[
     …
-    "author" : [
-        {
-            "type" : ["Person"],
-            "name" : "Ralph Ellison"
-        }
-    ],
+    "author" → « 
+        «[
+            "type" → « "Person" »
+            "name" → "Ralph Ellison"
+        ]»
+    »,
     …
-}</pre>
+]»</pre>
 								<p class="note">For simplicity, the conversion of <var>name</var> to a localizable
 									string is described by a later step.</p>
 							</details>
@@ -3124,24 +3162,24 @@
 							<details>
 								<summary>Explanation</summary>
 								<p>Natural language text values are expected to be explicitly designed as localizable
-									string objects, but, for the sake of convenience, can be simple strings. For
-									example, if no language information has been provided via the <a
+									string objects, but, for the sake of convenience, can be simple strings in the
+									manifest. For example, if no language information has been provided via the <a
 										href="#manifest-lang-dir-global">global language declaration</a> then:</p>
 								<pre class="example">{
-    "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
+    "@context" : ["https://schema.org", "https://www.w3.org/ns/pub-context"],
     "name"     : ["La Comédie humaine"],
     …
 }</pre>
 								<p>yields:</p>
-								<pre class="example">{
-    "@context" : ["https://schema.org","https://www.w3.org/ns/pub-context"],
-    "name"     : [
-        {
-            "value" : "La Comédie humaine"
-        }
-    ],
+								<pre class="example">«[
+    "@context" → « "https://schema.org", "https://www.w3.org/ns/pub-context" »,
+    "name"     → «
+        «[
+            "value" → "La Comédie humaine"
+        ]»
+    »,
     …
-}</pre>
+]»</pre>
 								<p>If, however, an explicit language has been provided in the manifest, that language is
 									added to the localizable string object. For example,</p>
 								<pre class="example">{
@@ -3155,17 +3193,17 @@
 }</pre>
 								<p>yields:</p>
 								<pre class="example">{
-    "@context" : [
+    "@context" → « 
         "https://schema.org",
         "https://www.w3.org/ns/pub-context",
-        {"language": "fr"}
-    ],
-    "name"     : [
-        {
-            "value"    : "La Comédie humaine",
-            "language" : "fr"
-        }
-    ],
+        «["language" → "fr"]»
+    »,
+    "name"     → «
+        «[
+            "value"    → "La Comédie humaine"
+            "language" → "fr"
+        ]»
+    »,
     …
 }</pre>
 								<p>A local setting or a local <code>null</code> value prevents the global value from
@@ -3191,22 +3229,27 @@
 }</pre>
 								<p>yields:</p>
 								<pre class="example">{
-    "@context" : [
+    "@context" → « 
         "https://schema.org",
-        "https://www.w3.org/ns/pub-context", 
-        {"language":"fr"}
-    ],
+        "https://www.w3.org/ns/pub-context",
+        «["language" → "fr"]»
+    »,
     …
-    "name" : [{
-        "value" : "La Comédie humaine",
-        "language": "fr"
-	}],
-    "publisher" : [{
-        "type":["Organization"],
-        "name":[{
-            "value": "Hachette",
-        }]
-    }],
+    "name"     → «
+        «[
+            "value"    → "La Comédie humaine"
+            "language" → "fr"
+        ]»
+    »,
+    "publisher"    → «
+        «[
+            "type" → « "Organization" »,
+            "name" → «
+                «[
+                    "value" → "Hachette",
+                ]»
+        ]»
+    »,
     …
 }</pre>
 							</details>
@@ -3239,7 +3282,7 @@
 								<summary>Explanation</summary>
 								<p>Resource links are expected to be explicitly designed as an object of type
 										<code>LinkedResource</code>, but, for the sake of convenience, only their
-									absolute or relative URL has to be specified. For example,</p>
+									absolute or relative URL has to be specified in the manifest. For example,</p>
 								<pre class="example">{
     …
     "resources" : [
@@ -3250,17 +3293,17 @@
 }</pre>
 								<p>This step converts the string values to objects, yielding the following for the
 									preceding example:</p>
-								<pre class="example">{
+								<pre class="example">«[
     …
-    "resources" : [
-        {
-            "type" : ["LinkedResource"],
-            "url"  : "css/book.css"
-        },
+    "resources" → «
+        «[
+            "type" → « "LinkedResource" »,
+            "url"  → "css/book.css"
+        ]»,
         …
-    ],
+    »,
     …
-}</pre>
+]»</pre>
 								<p class="note">For simplicity, the conversion of relative paths to absolute is
 									described by a later step.</p>
 							</details>
@@ -3269,12 +3312,16 @@
 						<li id="normalize-urls">
 							<p>(<a href="#value-url"></a>) If <var>term</var> expects a <a href="#value-url">URL</a> or
 									<a href="#value-array">array</a> of URLs, set <var>normalized</var> to the result of
-								running <a>absolute URL check</a>, when successful, given <var>normalized</var>.
+								running <a>convert to absolute URL</a>, when successful, given <var>normalized</var>.
 								Otherwise, return failure.</p>
 							<details>
 								<summary>Explanation</summary>
-								<p>All relative URLs in the publication manifest must be resolved against the base value
-									to yield absolute URLs.</p>
+								<p>Relative URLs in the manifest are resolved against the base value to obtain absolute
+									URLs. For example:</p>
+								<pre>"url": "chapter01.html"</pre>
+								<p>for a publication hosted at
+										<code>https://example.org/publications/wuthering-heights</code> would yield:</p>
+								<pre>"url" → "https://example.org/publications/wuthering-heights/chater01.html"</pre>
 							</details>
 						</li>
 
@@ -3283,25 +3330,39 @@
 								steps for profile-specific terms, those steps are executed at this point.</p>
 						</li>
 
-						<li id="normalize-recurse-lists">
-							<p>if <var>normalized</var> is a <a href="https://infra.spec.whatwg.org/#list">list</a>, <a
-									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-								<var>item</var> of <var>normalized</var> that is a <a
-									href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
-									href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
-								<var>key</var> → <var>keyValue</var> of <var>normalized</var>, set <var>key</var> to the
-								result of running <a href="#processing-normalize">normalize data</a> given
-									<var>key</var>, <var>keyValue</var>, <var>lang</var>, <var>dir</var> and
-									<var>base</var>.</p>
-						</li>
-
-						<li id="normalize-recurse-maps">
-							<p>if <var>normalized</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
-									>map</a>, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
-								<var>key</var> → <var>keyValue</var> of <var>normalized</var>, set <var>key</var> to the
-								result of running <a href="#processing-normalize">normalize data</a> given
-									<var>key</var>, <var>keyValue</var>, <var>lang</var>, <var>dir</var> and
-									<var>base</var>.</p>
+						<li id="normalize-recurse">
+							<p>Recursively check <var>normalized</var> as follows to ensure that all properties get
+								normalized:</p>
+							<ol>
+								<li>
+									<p>if <var>normalized</var> is a <a href="https://infra.spec.whatwg.org/#list"
+											>list</a>, <a href="https://infra.spec.whatwg.org/#list-iterate">for
+											each</a>
+										<var>item</var> of <var>normalized</var> that is a <a
+											href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
+											href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+										<var>key</var> → <var>keyValue</var> of <var>normalized</var>, set
+											<var>key</var> to the result of running <a href="#processing-normalize"
+											>normalize data</a> given <var>key</var>, <var>keyValue</var>,
+											<var>lang</var>, <var>dir</var>, <var>base</var> and <var>context</var>.</p>
+								</li>
+								<li>
+									<p>if <var>normalized</var> is a <a
+											href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
+											href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+										<var>key</var> → <var>keyValue</var> of <var>normalized</var>, set
+											<var>key</var> to the result of running <a href="#processing-normalize"
+											>normalize data</a> given <var>key</var>, <var>keyValue</var>,
+											<var>lang</var>, <var>dir</var>, <var>base</var> and <var>context</var>.</p>
+								</li>
+							</ol>
+							<details>
+								<summary>Explanation</summary>
+								<p>In order to ensure that all the properties in the manifest get processed, this step
+									recursively checks <var>normalized</var> for additional map entries to process. If
+										<var>normalized</var> is a list, each item is inspected to determine if it is a
+									map that can be processed.</p>
+							</details>
 						</li>
 
 						<li id="normalize-end">
@@ -3309,35 +3370,44 @@
 						</li>
 					</ol>
 
-					<section id="absolute-url-check">
-						<h4>Absolute URL Check</h4>
-						
-						<p>To perform an <dfn>absolute URL check</dfn> on <var>data</var>, with a base URL <var>base</var>,
-							run the following steps:</p>
-						
+					<section id="convert-absolute-url">
+						<h4>Convert to Absolute URL</h4>
+
+						<p>To <dfn>convert to absolute URL</dfn>
+							<var>value</var>, with a base URL <var>base</var>, run the following steps:</p>
+
 						<ol>
-							<li>
-								<p>if <var>data</var> is a <a href="https://infra.spec.whatwg.org/#string">string</a>, set
-									<var>data</var> to the result of running the <a
+							<li id="abs-url-convert">
+								<p>if <var>value</var> is a <a href="https://infra.spec.whatwg.org/#string">string</a>,
+									set <var>value</var> to the result of running the <a
 										href="https://url.spec.whatwg.org/#concept-url-parser">URL parser</a> with
-									<var>data</var> as input and <var>base</var> as the base URL.</p>
+										<var>value</var> as input and <var>base</var> as the base URL.</p>
 							</li>
-							<li>
-								<p>otherwise, if <var>data</var> is a <a href="https://infra.spec.whatwg.org/#list"
-									>list</a>, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-									<var>item</var> of <var>data</var>, set <var>item</var> to the result of runing
-									<a>absolute URL check</a>, when successful, given <var>item</var> and
-									<var>base</var>. Otherwise, <a href="https://infra.spec.whatwg.org/#list-remove"
+							<li id="abs-url-recurse">
+								<p>otherwise, if <var>value</var> is a <a href="https://infra.spec.whatwg.org/#list"
+										>list</a>, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+									<var>item</var> of <var>value</var>, set <var>item</var> to the result of runing
+										<a>convert to absolute URL</a>, when successful, given <var>item</var> and
+										<var>base</var>. Otherwise, <a href="https://infra.spec.whatwg.org/#list-remove"
 										>remove</a>
-									<var>item</var> from <var>data</var>.</p>
+									<var>item</var> from <var>value</var>.</p>
 							</li>
-							<li>
+							<li id="abs-url-error">
 								<p>otherwise, <a>validation error</a>, return failure.</p>
 							</li>
-							<li>
-								<p>Return <var>data</var>.</p>
+							<li id="abs-url-return">
+								<p>Return <var>value</var>.</p>
 							</li>
 						</ol>
+						<details>
+							<summary>Explanation</summary>
+							<p>This function checks if the value sent into it is a relative URL, and, if so, converts it
+								to an absolute URL. If the value is a <a href="https://infra.spec.whatwg.org/#list"
+									>list</a>, each item in the list is recursively passed to this function to inspect
+								it.</p>
+							<p>If the value passed to the function is not a string or a list, a failure is returned.
+								Otherwise, the updated value is returned.</p>
+						</details>
 					</section>
 				</section>
 
@@ -3352,8 +3422,15 @@
 						<li id="validate-general">
 							<p><a href="https://infra.spec.whatwg.org/#map-iterate">For each</a>
 								<var>term</var> → <var>value</var> of <var>data</var>, set <var>term</var> to the result
-								of running the <a>common data checks</a>, when successful, given <var>term</var> and
-									<var>value</var>. If a failure occurs, remove <var>data[term]</var>.</p>
+								of running the <a>global data checks</a>, when successful, given <var>term</var> and
+									<var>value</var>, and using <var>term</var> as the context. If a failure occurs,
+								remove <var>data[term]</var>.</p>
+							<details>
+								<summary>Explanation</summary>
+								<p>This step passes each entry to a set of global validation checks that need to be run
+									on the value and recursively on any properties within the value.</p>
+								<p>A failure is returned if the property is invalid and has to be removed.</p>
+							</details>
 						</li>
 
 						<li id="validate-type">
@@ -3421,7 +3498,7 @@
 								point.</p>
 						</li>
 
-						<li id="processing-remove-empty-arrays">
+						<li id="validate-empty-arrays">
 							<p><a href="https://infra.spec.whatwg.org/#map-iterate">For each</a>
 								<var>term</var> → <var>value</var> of <var>data</var>, if running <a>remove empty
 									arrays</a> given the variables <var>term</var> and <var>value</var> returns failure,
@@ -3439,212 +3516,289 @@
 							<p>Return <var>data</var>.</p>
 						</li>
 					</ol>
-					
-					<section id="common-data-checks">
-						<h4>Common Data Checks</h4>
-						
-						<p>To process the <dfn>common data checks</dfn> on a property <var>term</var>'s <var>value</var>,
-							run these steps:</p>
-						
+
+					<section id="global-data-checks">
+						<h4>Global Data Checks</h4>
+
+						<p>To process the <dfn>global data checks</dfn> on a property <var>term</var>'s <var>value</var>
+							with a <a>context</a>
+							<var>context</var>, run these steps:</p>
+
 						<ol>
-							<li id="common-checks-value-categories">
+							<li id="global-value-categories">
 								<p>(<a href="#properties-value-categories"></a>) If <var>term</var> has a known <a
-									href="#properties-value-categories">value category</a>, set <var>value</var> to the
-									result of calling <a>check category type</a>, when successful, given the variables
-									<var>term</var> and <var>value</var>. Otherwise, return failure.</p>
+										href="#properties-value-categories">value category</a>, set <var>value</var> to
+									the result of calling <a>verify value category</a>, when successful, given the
+									variables <var>term</var>, <var>value</var> and <var>context</var>. Otherwise,
+									return failure.</p>
+								<details>
+									<summary>Explanation</summary>
+									<p>This step verifies that the value of the term matches the expected category
+										required for the term. For example, the abridged term requires a boolean value,
+										so any other value used with the term will result in a failure.</p>
+									<p>If a failure occurs calling the function, this step also returns a failure so
+										that the property is removed from the final data set.</p>
+								</details>
 							</li>
-							<li id="common-checks-entities">
+
+							<li id="global-entities">
 								<p>(<a href="#value-entity"></a>) If <var>term</var> expects an <a href="#value-array"
-									>array</a> of <a href="#value-entity">entities</a>, <a
+										>array</a> of <a href="#value-entity">entities</a>, <a
 										href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-									<var>item</var> of <var>value</var>, check whether <var>item["name"]</var> is set:</p>
+									<var>item</var> of <var>value</var>, check whether <var>item["name"]</var> is
+									set:</p>
 								<ul>
 									<li>
 										<p>If not, <a>validation error</a>, <a
-											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+												href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 											<var>item</var> from <var>value</var>.</p>
 									</li>
 									<li>If so, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-										<var>name</var> of <var>item["name"]</var>, if <var>name["value"]</var> is not set,
-										or is an empty string, <a href="https://infra.spec.whatwg.org/#list-remove"
+										<var>name</var> of <var>item["name"]</var>, if <var>name["value"]</var> is not
+										set, or is an empty string, <a href="https://infra.spec.whatwg.org/#list-remove"
 											>remove</a>
 										<var>name</var> from <var>item["name"]</var>.</li>
 								</ul>
+								<details>
+									<summary>Explanation</summary>
+									<p>This step ensures that all entities have a name. Entities without a name are
+										removed.</p>
+								</details>
 							</li>
-							
-							<li id="common-checks-language">
-								<p>(<a href="#manifest-lang-dir-global"></a> and <a href="#manifest-lang-dir-local"></a>) If
-									<var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
+
+							<li id="global-language">
+								<p>(<a href="#manifest-lang-dir-global"></a> and <a href="#manifest-lang-dir-local"
+									></a>) If <var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
 										>map</a>:</p>
 								<ul>
 									<li>
 										<p>if <var>value["language"]</var> is set and its value is not <a
-											href="https://tools.ietf.org/html/bcp47#section-2.2.9"
+												href="https://tools.ietf.org/html/bcp47#section-2.2.9"
 											>well-formed</a>&#160;[[!bcp47]], <a>validation error</a>, <a
 												href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 											<var>value["language"]</var>.</p>
 										<p>if <var>value["direction"]</var> is set and its value is not one of
-											"<code>ltr</code>" or "<code>rtl</code>", <a>validation error</a>, <a
+												"<code>ltr</code>" or "<code>rtl</code>", <a>validation error</a>, <a
 												href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 											<var>value["direction"]</var>.</p>
 									</li>
 								</ul>
+								<details>
+									<summary>Explanation</summary>
+									<p>This step checks is language declarations are well formed, and removes them if
+										not.</p>
+									<p>Similarly, it checks that all direction declarations have either the value "ltr"
+										or "rtl".</p>
+								</details>
 							</li>
-							
-							<li id="common-checks-linkedresource">
+
+							<li id="global-linkedresource">
 								<p>(<a href="#value-linked-resource"></a>) If <var>term</var> expects an <a
-									href="#value-array">array</a> of <a href="#LinkedResource-def">LinkedResources</a>,
-									<a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+										href="#value-array">array</a> of <a>LinkedResources</a>, <a
+										href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
 									<var>resource</var> of <var>value</var>:</p>
 								<ul>
 									<li>
 										<p>if <var>resource["url"]</var> is not set, or its value is an empty string,
-											<a>validation error</a>, <a
+												<a>validation error</a>, <a
 												href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 											<var>resource</var> from <var>value</var>, then <a
-												href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
+												href="https://infra.spec.whatwg.org/#iteration-continue"
+											>continue</a>.</p>
 										<p>Otherwise, if <var>resource["url"]</var> is not a valid URL&#160;[[!url]],
-											<a>validation error</a>, <a
+												<a>validation error</a>, <a
 												href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 											<var>resource</var> from <var>value</var>, then <a
-												href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
+												href="https://infra.spec.whatwg.org/#iteration-continue"
+											>continue</a>.</p>
 									</li>
 									<li>
-										<p>if <a href="#linkedresource-length"><var>resource["length"]</var></a> is set and
-											is not a number, or is a negative number, <a>validation error</a>, <a
+										<p>if <a href="#linkedresource-length"><var>resource["length"]</var></a> is set
+											and is not a number, or is a negative number, <a>validation error</a>, <a
 												href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 											<var>resource["length"]</var>.</p>
 									</li>
 									<li>
-										<p>if <a href="#linkedresource-alternate"><var>resource["alternate"]</var></a> is
-											set, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+										<p>if <a href="#linkedresource-alternate"><var>resource["alternate"]</var></a>
+											is set, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
 											<var>alternate</var> of <var>resource["alterate"]</var>, if
-											<var>alternate["encodingFormat"]</var> is not set, <a>validation
+												<var>alternate["encodingFormat"]</var> is not set, <a>validation
 												error</a>.</p>
 									</li>
 								</ul>
+								<details>
+									<summary>Explanation</summary>
+									<p>This step performs three checks on the terms of a
+										<code>LinkedResource</code>:</p>
+									<ol>
+										<li>If a URL is not specified, or is invalid, the <code>LinkedResource</code> is
+											removed.</li>
+										<li>If the length of the resource is specified, and is not a positive number,
+											the length is removed.</li>
+										<li>If there are alternate resources associated with the
+												<code>LinkedResource</code>, each is inspected to see if its media type
+											is specified.</li>
+									</ol>
+								</details>
 							</li>
-							
-							<li id="common-checks-recurse-maps">
-								<p>If <var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
-									href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
-									<var>key</var> → <var>keyValue</var> of <var>value</var>, set <var>value[key]</var> to
-									the result of running <a>common data checks</a> given <var>key</var> and
-									<var>keyValue</var>.</p>
+
+							<li id="global-recurse">
+								<p>Recursively check <var>value</var> as follows to ensure that all properties are
+									verified:</p>
+								<ol>
+									<li id="global-recurse-maps">
+										<p>If <var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
+												>map</a>, <a href="https://infra.spec.whatwg.org/#map-iterate">for
+												each</a>
+											<var>key</var> → <var>keyValue</var> of <var>value</var>, set
+												<var>value[key]</var> to the result of running <a>global data checks</a>
+											given <var>key</var> and <var>keyValue</var>.</p>
+									</li>
+
+									<li id="global-recurse-lists">
+										<p>If <var>value</var> is a <a href="https://infra.spec.whatwg.org/#list"
+												>list</a>, <a href="https://infra.spec.whatwg.org/#list-iterate">for
+												each</a>
+											<var>item</var> of <var>value</var>, if <var>item</var> is a <a
+												href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
+												href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+											<var>key</var> → <var>keyValue</var> of <var>value</var>, set
+												<var>value[key]</var> to the result of running <a>global data checks</a>
+											given <var>key</var> and <var>keyValue</var>.</p>
+									</li>
+								</ol>
+								<details>
+									<summary>Explanation</summary>
+									<p>In order to ensure that all the properties in the manifest get processed, this
+										step recursively checks each entry for additional map entries to process. If the
+										value is a list, each item is inspected to determine if it is a map that can be
+										processed.</p>
+								</details>
 							</li>
-							
-							<li id="common-checks-recurse-lists">
-								<p>If <var>value</var> is a <a href="https://infra.spec.whatwg.org/#list">list</a>, <a
-									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-									<var>item</var> of <var>value</var>, if <var>item</var> is a <a
-										href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
-											href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
-									<var>key</var> → <var>keyValue</var> of <var>value</var>, set <var>value[key]</var> to
-									the result of running <a>common data checks</a> given <var>key</var> and
-									<var>keyValue</var>.</p>
-							</li>
-							
-							<li id="common-check-end">
+
+							<li id="global-end">
 								<p>Return <var>value</var>.</p>
 							</li>
 						</ol>
+
+						<details>
+							<summary>Explanation</summary>
+						</details>
 					</section>
-					
-					<section id="category-check">
-						<h4>Check Category Type</h4>
-						
-						<p>To <dfn>check category type</dfn> of a property <var>term</var>'s <var>value</var>, run these
-							steps:</p>
-						
+
+					<section id="verify-value-category">
+						<h4>Verify Value Category</h4>
+
+						<p>To <dfn>verify value category</dfn> of a property <var>term</var>'s <var>value</var> with a
+								<a>context</a>
+							<var>context</var>, run these steps:</p>
+
 						<ol>
-							<li>
-								<p>If <var>term</var> expects an <a href="#value-array">array</a>:</p>
+							<li id="verify-array">
+								<p>If, depending on the <var>context</var>, <var>term</var> expects an <a
+										href="#value-array">array</a>:</p>
 								<ol>
-									<li>
+									<li id="verify-array-invalid">
 										<p>if <var>value</var> is not a <a href="https://infra.spec.whatwg.org/#list"
-											>list</a>, <a>validation error</a>, return failure.</p>
+												>list</a>, <a>validation error</a>, return failure.</p>
 									</li>
-									<li>
+									<li id="verify-array-item-check">
 										<p>otherwise, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
 											<var>item</var> of <var>value</var>:</p>
 										<ol>
-											<li>
+											<li id="verify-array-item-invalid">
 												<p>if <var>item</var> does not match the expected type of the array,
-													<a>validation error</a>, <a
+														<a>validation error</a>, <a
 														href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 													<var>item</var> from <var>value</var>, then <a
 														href="https://infra.spec.whatwg.org/#iteration-continue"
 														>continue</a>.</p>
 											</li>
-											<li>
+											<li id="verify-array-item-recurse">
 												<p>if <var>item</var> is a <a
-													href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
+														href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
 														href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
 													<var>key</var> → <var>keyValue</var> of <var>item</var>, if
-													<var>key</var> has an expected type, set <var>key</var> to the
-													result of running <a>check category type</a> given the variables
-													<var>key</var> and <var>keyValue</var>. If the result of processing
-													<var>item</var> is an empty <a
+														<var>key</var> has an expected type, set <var>key</var> to the
+													result of running <a>verify value category</a> given the variables
+														<var>key</var> and <var>keyValue</var>. If the result of
+													processing <var>item</var> is an empty <a
 														href="https://infra.spec.whatwg.org/#ordered-map">map</a>,
-													<a>validation error</a>, <a
+														<a>validation error</a>, <a
 														href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 													<var>item</var> from <var>value</var>.</p>
 											</li>
 										</ol>
-										<p>If the result of processing <var>value</var> is an empty <a href="#value-array"
-											>array</a>, <a>validation error</a>, return failure.</p>
+										<p>If the result of processing <var>value</var> is an empty <a
+												href="#value-array">array</a>, <a>validation error</a>, return
+											failure.</p>
 									</li>
 								</ol>
 							</li>
-							<li>
-								<p>Otherwise, if <var>term</var> expects a <a
-									href="https://infra.spec.whatwg.org/#ordered-map">map</a>:</p>
+							<li id="verify-map">
+								<p>Otherwise, if, depending on the <var>context</var>
+									<var>term</var> expects a <a href="https://infra.spec.whatwg.org/#ordered-map"
+										>map</a>:</p>
 								<ol>
-									<li>
-										<p>if <var>value</var> is not a <a href="https://infra.spec.whatwg.org/#ordered-map"
-											>map</a>, <a>validation error</a>, return failure.</p>
-									</li>
-									<li>
-										<p>otherwise, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
-											<var>key</var> → <var>keyValue</var> of <var>value</var>, if <var>key</var> has
-											an expected type, set <var>key</var> to the result of running <a>check category
-												type</a> given <var>key</var> and <var>keyValue</var>. If the result of
-											processing <var>value</var> is an empty <a
+									<li id="verify-map-invalid">
+										<p>if <var>value</var> is not a <a
 												href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>validation
-													error</a>, return failure.</p>
+												error</a>, return failure.</p>
+									</li>
+									<li id="verify-map-recurse">
+										<p>otherwise, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+											<var>key</var> → <var>keyValue</var> of <var>value</var>, if <var>key</var>
+											has an expected type, set <var>key</var> to the result of running <a>verify
+												value category</a> given <var>key</var> and <var>keyValue</var>. If the
+											result of processing <var>value</var> is an empty <a
+												href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>validation
+												error</a>, return failure.</p>
 									</li>
 								</ol>
 							</li>
-							<li>
-								<p>Otherwise, if <var>value</var> does not have the expected type of <var>term</var>,
-									<a>validation error</a>, return failure.</p>
+							<li id="verify-type-invalid">
+								<p>Otherwise, if, depending on the <var>context</var>, <var>value</var> does not have
+									the expected type of <var>term</var>, <a>validation error</a>, return failure.</p>
 							</li>
-							<li>
+							<li id="verify-return">
 								<p>Return <var>value</var>.</p>
 							</li>
 						</ol>
+						<details>
+							<summary>Explanation</summary>
+							<p>This function checks that the value of the term being processed matches its expected
+								value category. The function is recursively called when the value is a list or map to
+								ensure that all properties in the manifest get checked.</p>
+						</details>
 					</section>
-					
+
 					<section id="remove-empty-arrays">
 						<h4>Remove Empty Arrays</h4>
-						
-						<p>To <dfn>remove empty arrays</dfn> from a property <var>term</var>'s <var>value</var>, run these
-							steps:</p>
-						
+
+						<p>To <dfn>remove empty arrays</dfn> from a property <var>term</var>'s <var>value</var>, run
+							these steps:</p>
+
 						<ol>
 							<li>
-								<p>If <var>value</var> is an empty <a href="https://infra.spec.whatwg.org/#list">list</a>,
-									return failure.</p>
+								<p>If <var>value</var> is an empty <a href="https://infra.spec.whatwg.org/#list"
+										>list</a>, return failure.</p>
 							</li>
 							<li>
-								<p>Otherwise, if <var>value</var> is a <a href="https://infra.spec.whatwg.org/#ordered-map"
-									>map</a>, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
+								<p>Otherwise, if <var>value</var> is a <a
+										href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
+										href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
 									<var>key</var> → <var>keyValue</var> of <var>value</var>, if running <a>remove empty
 										arrays</a> given <var>key</var> and <var>keyValue</var> returns failure, <a
-											href="https://infra.spec.whatwg.org/#map-remove">remove</a>
+										href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 									<var>value[key]</var>.</p>
 							</li>
 						</ol>
+						<details>
+							<summary>Explanation</summary>
+							<p>This function checks that the value of the term being processed is not an empty list. A
+								term that initially has a list can lose entries as it gets processed (i.e., when the
+								list items are invalid).</p>
+						</details>
 					</section>
 				</section>
 
@@ -3653,7 +3807,8 @@
 
 					<p>To <dfn>add HTML defaults</dfn> for missing properties in <a
 							href="https://infra.spec.whatwg.org/#ordered-map">map</a>
-						<var>data</var> with a HTML document node <var>document</var>, run the following steps:</p>
+						<var>data</var> with an <a data-cite="html#the-document-object">HTML Document (DOM)
+						Node</a>&#160;[[!html]] <var>document</var>, run the following steps:</p>
 
 					<ol>
 						<li id="processing-defaults-title">
@@ -3705,16 +3860,16 @@
     }
     &lt;/script&gt;</pre>
 								<p>yields:</p>
-								<pre class="example">{
+								<pre class="example">«[
     …
-    "name" : [
-        {
-            "value" : "The Golden Bough",
-            "language" : "en"
-        }
-    ],
+    "name" → «
+        «[
+            "value"    → "The Golden Bough",
+            "language" → "en"
+        ]»
+    »,
     …
-}</pre>
+]»</pre>
 							</details>
 						</li>
 
@@ -3842,7 +3997,8 @@
 					<pre id="wpm">
 dictionary PublicationManifest {
              sequence&lt;DOMString>         type = "CreativeWork";
-    required sequence&lt;DOMString>         conformsTo;
+    required DOMString                 profile;
+             sequence&lt;DOMString>         conformsTo;
              DOMString                   id;
              boolean                     abridged;
              sequence&lt;DOMString>         accessMode;

--- a/index.html
+++ b/index.html
@@ -371,13 +371,17 @@
 							as its value, the value MUST be expressed either as:</p>
 
 						<ul>
-							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a> value;
-								or</li>
-							<li>A <a><code>LocalizableString</code></a>.</li>
+							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
+								value;</li>
+							<li>a <a><code>LocalizableString</code></a>; or</li>
+							<li>an <a href="#value-array">Array</a> of <a><code>LocalizableStrings</code></a>.</li>
 						</ul>
 
 						<p>A single string value represents an implied object whose <code>value</code> property is the
 							string's text and whose language is determined from other information in the manifest.</p>
+
+						<p>Although only a single string or object has to be authored, properties that accept
+							localizable strings are always converted to <a href="#value-array">arrays</a>.</p>
 
 						<p>A <dfn data-lt="LocalizableStrings|localizable string"><code>LocalizableString</code></dfn>
 							is a [[!json]]&#160;<a href="https://tools.ietf.org/html/rfc4627#section-2.2">object</a>


### PR DESCRIPTION
This PR makes the following changes:

- updates the processing algorithm to split it into more atomic functions where appropriate (makes the main algorithm clearer and also makes it easier for profiles to extend specific functions instead of step numbers).
- updates description and accessibilitySummary to arrays of localizable strings.
- standardizes the name "value category".
- adds a generic object category and updates accessModeSufficient to reference it.
- adds prose for reading systems to inspect reading order for unknown profiles and react accordingly.

It should fix #101 #106 #108 #109 #110 #113 and #115

I'm going to update the experimental processor code next just to make sure I didn't break anything splitting up the algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/116.html" title="Last updated on Oct 18, 2019, 1:59 PM UTC (b768200)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/116/07f264d...b768200.html" title="Last updated on Oct 18, 2019, 1:59 PM UTC (b768200)">Diff</a>