### PR TITLE
add canonical id check

### DIFF
--- a/index.html
+++ b/index.html
@@ -3459,14 +3459,6 @@
 								to <code>«&#160;"CreativeWork"&#160;»</code>.</p>
 						</li>
 
-						<!-- handled by category check
-						<li id="validate-abridged">
-							<p>(<a href="#abridged"></a>) If <var>data["abridged"]</var> is set and is not a <a
-									href="https://infra.spec.whatwg.org/#boolean">boolean</a>, <a>validation error</a>,
-									<a href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-								<var>data["abridged"]</var>.</p>
-						</li>-->
-
 						<li id="validate-ams">
 							<p>(<a href="#accessibility"></a>) If <var>data["accessModeSufficient"]</var> is set, <a
 									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
@@ -3474,6 +3466,12 @@
 								not set or is not "<code>ItemList</code>", <a
 									href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 								<var>ams</var> from <var>data["accessModeSufficient"]</var>.</p>
+						</li>
+
+						<li id="validate-id">
+							<p>(<a href="#canonical-identifier"></a>) If <var>data["id"]</var> is not set or is an empty
+									<a href="https://infra.spec.whatwg.org/#string">string</a>, <a>validation
+								error</a>.</p>
 						</li>
 
 						<li id="validate-duration">


### PR DESCRIPTION
Fixes #124. Adds warning if canonical id isn't set or is an empty string.

We already have a check for type that generates a warning and adds CreativeWork. I guess that was a leftover from when it was required.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/125.html" title="Last updated on Oct 19, 2019, 9:51 PM UTC (3b3a7c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/125/a15c211...3b3a7c3.html" title="Last updated on Oct 19, 2019, 9:51 PM UTC (3b3a7c3)">Diff</a>