### PR TITLE
Add recommendation to note severity

### DIFF
--- a/index.html
+++ b/index.html
@@ -2828,6 +2828,9 @@
 
 				<p>User agents SHOULD expose both validation and fatal errors, but this specification does not prescribe
 					the manner in which this is done.</p>
+
+				<p>For validation errors, user agents SHOULD differentiate the severity (i.e., whether a required or
+					recommended practice has been violated).</p>
 			</section>
 
 			<section id="processing-algorithm">

--- a/index.html
+++ b/index.html
@@ -2829,8 +2829,8 @@
 				<p>User agents SHOULD expose both validation and fatal errors, but this specification does not prescribe
 					the manner in which this is done.</p>
 
-				<p>For validation errors, user agents SHOULD differentiate the severity (i.e., whether a required or
-					recommended practice has been violated).</p>
+				<p>For validation errors, user agents SHOULD indicate the severity of the error (i.e., whether a
+					required or recommended practice has been violated).</p>
 			</section>
 
 			<section id="processing-algorithm">

--- a/index.html
+++ b/index.html
@@ -2829,8 +2829,8 @@
 				<p>User agents SHOULD expose both validation and fatal errors, but this specification does not prescribe
 					the manner in which this is done.</p>
 
-				<p>For validation errors, user agents SHOULD differentiate the severity of the error &#8212; errors for
-					broken requirements and warnings for recommended practices.</p>
+				<p>For validation errors, user agents SHOULD differentiate the severity of the error (i.e., whether a
+					required or recommended practice has been violated).</p>
 			</section>
 
 			<section id="processing-algorithm">

--- a/index.html
+++ b/index.html
@@ -2829,8 +2829,8 @@
 				<p>User agents SHOULD expose both validation and fatal errors, but this specification does not prescribe
 					the manner in which this is done.</p>
 
-				<p>For validation errors, user agents SHOULD indicate the severity of the error (i.e., whether a
-					required or recommended practice has been violated).</p>
+				<p>For validation errors, user agents SHOULD differentiate the severity of the error &#8212; errors for
+					broken requirements and warnings for recommended practices.</p>
 			</section>
 
 			<section id="processing-algorithm">


### PR DESCRIPTION
Per #122, this PR adds a recommendation to note the severity of validation errors.

I'm kind of waffling on the wording of this one, so alternatives welcome.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/127.html" title="Last updated on Oct 20, 2019, 3:42 PM UTC (91b12f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/127/bfdeae3...91b12f6.html" title="Last updated on Oct 20, 2019, 3:42 PM UTC (91b12f6)">Diff</a>