### PR TITLE
Additional pub resources/algorithm cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -2246,8 +2246,7 @@
 						<p>The order of items is <em>not significant</em>.</p>
 
 						<p>To avoid conflicting information about a resource, a particular resource's <a>URL</a> SHOULD
-							NOT be repeated within the resource list. Only the first declaration of a resource is
-							retained during <a href="#manifest-processing">processing of the manifest</a>.</p>
+							NOT be repeated within the resource list.</p>
 
 						<p>The URLs expressed in the resource list SHOULD NOT include fragment identifiers.</p>
 
@@ -4046,6 +4045,31 @@
 										<p>otherwise, <a href="https://infra.spec.whatwg.org/#set-append">append</a>
 											<var>url</var> to <var>uniqueURLs</var></p>
 									</li>
+									<li id="unique-alternate-parse">
+										<p>if <var>resource["alternate"]</var> is set, for each <var>alternate</var> of
+												<var>resource["alternate"]</var>:</p>
+										<ol>
+											<li id="alternate-parse-url">
+												<p>let <var>alt_url</var> be the result of running <a
+														href="https://url.spec.whatwg.org/#concept-url-serializer">URL
+														serializer</a>&#160;[[!url]] on <var>alternate["url"]</var> with
+														<var>exclude fragment flag</var> set.</p>
+											</li>
+
+											<li id="alternate-parse-test">
+												<p>if <var>uniqueURLs</var>
+													<a href="https://infra.spec.whatwg.org/#list-contain">contains</a>
+													<var>alt_url</var>, <a>validation error</a>.</p>
+											</li>
+
+											<li id="alternate-parse-append">
+												<p>otherwise, <a href="https://infra.spec.whatwg.org/#set-append"
+														>append</a>
+													<var>alt_url</var> to <var>uniqueURLs</var></p>
+											</li>
+										</ol>
+									</li>
+
 								</ol>
 							</li>
 

--- a/index.html
+++ b/index.html
@@ -3001,14 +3001,13 @@
 									href="https://infra.spec.whatwg.org/#string">strings</a>, then <a
 									href="https://infra.spec.whatwg.org/#iteration-break">break</a>.</li>
 						</ol>
-						<p>If the value of <var>lang</var> is neither an empty <a
-								href="https://infra.spec.whatwg.org/#string">string</a> nor a <a
-								href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed</a>&#160;[[!bcp47]]
-							language tag, <a>validation error</a>, set <var>lang</var> to an empty string.</p>
-						<p>If the value of <var>dir</var> is neither an empty <a
-								href="https://infra.spec.whatwg.org/#string">string</a> nor one of the values
-								"<code>ltr</code>" or "<code>rtl</code>", <a>validation error</a>, set <var>dir</var> to
-							an empty string.</p>
+						<p>If <var>lang</var> is not an empty <a href="https://infra.spec.whatwg.org/#string">string</a>
+							and is not a <a href="https://tools.ietf.org/html/bcp47#section-2.2.9"
+							>well-formed</a>&#160;[[!bcp47]] language tag, <a>validation error</a>, set <var>lang</var>
+							to an empty string.</p>
+						<p>If <var>dir</var> is not an empty <a href="https://infra.spec.whatwg.org/#string">string</a>
+							and is not one of the values "<code>ltr</code>" or "<code>rtl</code>", <a>validation
+								error</a>, set <var>dir</var> to an empty string.</p>
 						<details>
 							<summary>Explanation</summary>
 							<p>The global language and direction declarations obtained here are used to set the language
@@ -3122,8 +3121,8 @@
 						</li>
 
 						<li id="normalize-entities">
-							<p>(<a href="#value-entity"></a>) If <var>term</var> expects an <a href="#value-array"
-									>array</a> of <a href="#value-entity">entities</a>, <a
+							<p>(<a href="#value-entity"></a>) If, depending on <var>context</var>, <var>term</var>
+								expects an <a href="#value-array">array</a> of <a href="#value-entity">entities</a>, <a
 									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
 								<var>entity</var> of <var>normalized</var>:</p>
 							<ol>
@@ -3180,9 +3179,10 @@
 						</li>
 
 						<li id="normalize-localizable-strings">
-							<p>(<a href="#value-localizable-string"></a>) If <var>term</var> expects an <a
-									href="#value-array">array</a> of <a href="#value-localizable-string">localizable
-									strings</a>, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+							<p>(<a href="#value-localizable-string"></a>) If, depending on <var>context</var>,
+									<var>term</var> expects an <a href="#value-array">array</a> of <a
+									href="#value-localizable-string">localizable strings</a>, <a
+									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
 								<var>item</var> of <var>normalized</var>:</p>
 							<ol>
 								<li id="ls-value-normalize">
@@ -3195,7 +3195,7 @@
     "direction" → <var>dir</var>
 ]»</pre>
 									<p>if <var>lang</var> or <var>dir</var> is not set, or is an empty <a
-											href="https://infra.spec.whatwg.org/#string">strings</a>, <a
+											href="https://infra.spec.whatwg.org/#string">string</a>, <a
 											href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 										<var>item["language"]</var> or <var>item["direction"]</var>, respectively.</p>
 								</li>
@@ -3326,10 +3326,10 @@
 						</li>
 
 						<li id="normalize-linked-resources">
-							<p>(<a href="#value-linked-resource"></a>) If <var>term</var> expects an <a
-									href="#value-array">array</a> of <a href="#value-linked-resource"
-									>LinkedResources</a>, <a href="https://infra.spec.whatwg.org/#list-iterate">for
-									each</a>
+							<p>(<a href="#value-linked-resource"></a>) If, depending on <var>context</var>,
+									<var>term</var> expects an <a href="#value-array">array</a> of <a
+									href="#value-linked-resource">LinkedResources</a>, <a
+									href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
 								<var>resource</var> of <var>normalized</var>:</p>
 							<ol>
 								<li>
@@ -3386,8 +3386,8 @@
 						</li>
 
 						<li id="normalize-urls">
-							<p>(<a href="#value-url"></a>) If <var>term</var> expects a <a href="#value-url">URL</a> or
-									<a href="#value-array">array</a> of URLs:</p>
+							<p>(<a href="#value-url"></a>) If, depending on <var>context</var>, <var>term</var> expects
+								a <a href="#value-url">URL</a> or <a href="#value-array">array</a> of URLs:</p>
 							<ol>
 								<li>
 									<p>if <var>normalized</var> is a <a href="https://infra.spec.whatwg.org/#string"

--- a/index.html
+++ b/index.html
@@ -165,7 +165,9 @@
 				</dl>
 			</section>
 
-			<section id="conformance"></section>
+			<section id="conformance">
+				<p>All explanations are <em>informative</em>.</p>
+			</section>
 		</section>
 		<section id="manifest">
 			<h2>Publication Manifest</h2>
@@ -2155,6 +2157,10 @@
 							their respective specifications (e.g., the start location to move the user to, or the range
 							of content to render before moving to the next item in the reading order).</p>
 
+						<p>Resources SHOULD NOT be listed more than once in the reading order, as this can lead to
+							unexpected results in user agents (e.g., links to the resource might not resolve to the
+							right instance in the reading order).</p>
+
 						<p>The default reading order MUST include at least one resource.</p>
 
 						<pre class="example" title="Expressing the reading order as a simple list of URLs.">{
@@ -2596,9 +2602,9 @@
 								publication</a> (e.g., in a library or bookshelf, or when initially loading the
 							publication).</p>
 
-						<p>The cover is identified by the <code>cover</code> link relation. The <a href="#value-url"
-								>URL</a> expressed in the <code>url</code> term MUST NOT include a fragment
-							identifier.</p>
+						<p>The cover is identified by the <code>cover</code> link relation.</p>
+
+						<p>The link to the cover MUST NOT be specified in the <a href="#links">links list</a>.</p>
 
 						<p class="ednote">The <code>cover</code> term is not currently registered in the IANA link
 							relations but the Working Group expects to add it.</p>
@@ -2669,9 +2675,7 @@
 						<p>The page list is a navigational aid that contains a list of static page demarcation points
 							within a <a>digital publication</a>.</p>
 
-						<p>The page list is identified by the <code>pagelist</code> link relation. The <a
-								href="#value-url">URL</a> expressed in the <code>url</code> term of the resource that
-							identifies the page list MUST NOT include a fragment identifier.</p>
+						<p>The page list is identified by the <code>pagelist</code> link relation.</p>
 
 						<p class="ednote">The <code>pagelist</code> term is not currently registered in the IANA link
 							relations but the Working Group expects to add it.</p>
@@ -2695,16 +2699,14 @@
 					<section id="pub-table-of-contents">
 						<h5>Table of Contents</h5>
 
-						<p>The table of contents is a navigational aid that provides links to the majort structural
+						<p>The table of contents is a navigational aid that provides links to the major structural
 							sections of a <a>digital publication</a>.</p>
 
 						<p>The <dfn data-lt="toc">table of contents</dfn> is identified by the <code>contents</code>
-							link relation&#160;[[!iana-link-relations]]. The <a href="#value-url">URL</a> expressed in
-							the <code>url</code> term of the resource that identifies the table of contents MUST NOT
-							include a fragment identifier.</p>
+							link relation&#160;[[!iana-link-relations]].</p>
 
-						<p>The link to the table of contents MUST NOT be specified in the <a
-								href="#default-reading-order">links list</a>.</p>
+						<p>The link to the table of contents MUST NOT be specified in the <a href="#links">links
+								list</a>.</p>
 
 						<p>The RECOMMENDED structure and processing model for the table of contents is defined in <a
 								href="#app-toc-structure"></a>.</p>
@@ -3095,11 +3097,9 @@
 
 						<li id="normalize-arrays">
 							<p>(<a href="#value-array"></a>) If, depending on <var>context</var>, <var>term</var>
-								expects an <a href="#value-array">array</a> and <var>value</var> is a <a
-									href="https://infra.spec.whatwg.org/#string">string</a>, <a
-									href="https://infra.spec.whatwg.org/#boolean">boolean</a>, number, null, or <a
-									href="https://infra.spec.whatwg.org/#ordered-map">map</a>, set <var>normalized</var>
-								to «&#160;<var>value</var>&#160;».</p>
+								expects an <a href="#value-array">array</a> and <var>value</var> is not a <a
+									href="https://infra.spec.whatwg.org/#list">list</a>, set <var>normalized</var> to
+									«&#160;<var>value</var>&#160;».</p>
 							<details>
 								<summary>Explanation</summary>
 								<p>A number of terms require their values to be arrays, but, for the sake of
@@ -3137,10 +3137,8 @@
 ]»</pre>
 								</li>
 								<li>
-									<p>otherwise, if <var>entity</var> is a <a
-											href="https://infra.spec.whatwg.org/#list">list</a>, number, <a
-											href="https://infra.spec.whatwg.org/#boolean">boolean</a> or <a
-											href="https://infra.spec.whatwg.org/#nulls">null</a>, <a>validation
+									<p>otherwise, if <var>entity</var> is not a <a
+											href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>validation
 											error</a>, <a href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 										<var>entity</var> from <var>normalized</var>.</p>
 								</li>
@@ -3202,11 +3200,9 @@
 										<var>item["language"]</var> or <var>item["direction"]</var>, respectively.</p>
 								</li>
 								<li id="ls-error">
-									<p>otherwise, if <var>item</var> is a <a href="https://infra.spec.whatwg.org/#list"
-											>list</a>, number, <a href="https://infra.spec.whatwg.org/#boolean"
-											>boolean</a> or <a href="https://infra.spec.whatwg.org/#nulls">null</a>,
-											<a>validation error</a>, remove <var>item</var> from
-										<var>normalized</var>.</p>
+									<p>otherwise, if <var>item</var> is not a <a
+											href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>validation
+											error</a>, remove <var>item</var> from <var>normalized</var>.</p>
 								</li>
 								<li id="ls-map-normalize">
 									<p>otherwise, process the <a href="https://infra.spec.whatwg.org/#ordered-map"
@@ -3345,10 +3341,8 @@
 ]»</pre>
 								</li>
 								<li>
-									<p>otherwise, if <var>resource</var> is a <a
-											href="https://infra.spec.whatwg.org/#list">list</a>, number, <a
-											href="https://infra.spec.whatwg.org/#boolean">boolean</a> or <a
-											href="https://infra.spec.whatwg.org/#nulls">null</a>, <a>validation
+									<p>otherwise, if <var>resource</var> is not a <a
+											href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>validation
 											error</a>, remove <var>resource</var> from <var>normalized</var>.</p>
 								</li>
 								<li>
@@ -3395,16 +3389,26 @@
 							<p>(<a href="#value-url"></a>) If <var>term</var> expects a <a href="#value-url">URL</a> or
 									<a href="#value-array">array</a> of URLs:</p>
 							<ol>
-								<li>if <var>normalized</var> is a <a href="https://infra.spec.whatwg.org/#list"
-									>list</a>, <a href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-									<var>item</var> of <var>normalized</var>, set <var>item</var> to the result of
-									running <a>convert to absolute URL</a>, when successful, given
-									<var>normalized</var>. Otherwise, <a
-										href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-									<var>item</var> from <var>normalized</var>.</li>
-								<li>otherwise, set <var>normalized</var> to the result of running <a
-										href="https://infra.spec.whatwg.org/#list-remove">convert to absolute URL</a>,
-									when successful, given <var>normalized</var>. Otherwise, return failure.</li>
+								<li>
+									<p>if <var>normalized</var> is a <a href="https://infra.spec.whatwg.org/#string"
+											>string</a>, set <var>normalized</var> to the result of running <a
+											href="https://infra.spec.whatwg.org/#list-remove">convert to absolute
+											URL</a>, when successful, given <var>normalized</var>. If failure is
+										returned, return failure.</p>
+								</li>
+								<li>
+									<p>otherwise, if <var>normalized</var> is a <a
+											href="https://infra.spec.whatwg.org/#list">list</a>, <a
+											href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+										<var>item</var> of <var>normalized</var>, set <var>item</var> to the result of
+										running <a>convert to absolute URL</a>, when successful, given
+											<var>normalized</var>. If failure is returned, <a
+											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+										<var>item</var> from <var>normalized</var>.</p>
+								</li>
+								<li>
+									<p>otherwise, <a>validation error</a>, return failure.</p>
+								</li>
 							</ol>
 							<details>
 								<summary>Explanation</summary>
@@ -3635,9 +3639,7 @@
 								<li>
 									<p>if <var>uniqueURLs</var>
 										<a href="https://infra.spec.whatwg.org/#list-contain">contains</a>
-										<var>url</var>, <a>validation error</a>, <a
-											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
-										<var>resource</var> from <var>data["resources"]</var>.</p>
+										<var>url</var>, <a>validation error</a>.</p>
 								</li>
 								<li>
 									<p>otherwise, <a href="https://infra.spec.whatwg.org/#set-append">append</a>
@@ -3673,6 +3675,13 @@
 										<a href="https://infra.spec.whatwg.org/#list-contain">contains</a>
 										<var>url</var>, <a>validation error</a>, <a
 											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
+										<var>link</var> from <var>data["links"]</var>.</p>
+								</li>
+								<li>
+									<p>if <var>link["rel"]</var> is set and <a
+											href="https://infra.spec.whatwg.org/#list-contains">contains</a> any of the
+										values "<code>toc</code>", "<code>pagelist</code>" or "<code>cover</code>",
+											<a>validation error</a>, <a>remove</a>
 										<var>link</var> from <var>data["links"]</var>.</p>
 								</li>
 							</ol>
@@ -3935,8 +3944,8 @@
 											<var>item</var> of <var>value</var>:</p>
 										<ol>
 											<li id="verify-array-item-invalid">
-												<p>if <var>item</var> does not match the expected type of the array,
-														<a>validation error</a>, <a
+												<p>if <var>item</var> does not match the expected value category of the
+													array, <a>validation error</a>, <a
 														href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 													<var>item</var> from <var>value</var>, then <a
 														href="https://infra.spec.whatwg.org/#iteration-continue"
@@ -3947,9 +3956,10 @@
 														href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
 														href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
 													<var>key</var> → <var>keyValue</var> of <var>item</var>, if
-														<var>key</var> has an expected type, set <var>key</var> to the
-													result of running <a>verify value category</a> given the variables
-														<var>key</var> and <var>keyValue</var>. If the result of
+														<var>key</var> has an expected value category, set
+														<var>key</var> to the result of running <a>verify value
+														category</a> given <var>key</var>, <var>keyValue</var>, and
+													using <var>item["type"]</var> as the context. If the result of
 													processing <var>item</var> is an empty <a
 														href="https://infra.spec.whatwg.org/#ordered-map">map</a>,
 														<a>validation error</a>, <a
@@ -3963,6 +3973,7 @@
 									</li>
 								</ol>
 							</li>
+
 							<li id="verify-map">
 								<p>Otherwise, if, depending on the <var>context</var>, <var>term</var> expects a <a
 										href="https://infra.spec.whatwg.org/#ordered-map">map</a>:</p>
@@ -3975,9 +3986,10 @@
 									<li id="verify-map-recurse">
 										<p>otherwise, <a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
 											<var>key</var> → <var>keyValue</var> of <var>value</var>, if <var>key</var>
-											has an expected type, set <var>key</var> to the result of running <a>verify
-												value category</a> given <var>key</var> and <var>keyValue</var>. If the
-											result of processing <var>value</var> is an empty <a
+											has an expected value category, set <var>key</var> to the result of running
+												<a>verify value category</a> given <var>key</var>, <var>keyValue</var>
+											and using <var>item["type"]</var> as the context. If the result of
+											processing <var>value</var> is an empty <a
 												href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>validation
 												error</a>, return failure.</p>
 									</li>
@@ -3986,10 +3998,13 @@
 									properties defined in this specification all accept <a href="#value-array"
 										>arrays</a> of objects.</p>
 							</li>
+
 							<li id="verify-type-invalid">
-								<p>Otherwise, if, depending on the <var>context</var>, <var>value</var> does not have
-									the expected type of <var>term</var>, <a>validation error</a>, return failure.</p>
+								<p>Otherwise, if, depending on the <var>context</var>, <var>value</var> does not match
+									the expected value category of <var>term</var>, <a>validation error</a>, return
+									failure.</p>
 							</li>
+
 							<li id="verify-return">
 								<p>Return <var>value</var>.</p>
 							</li>
@@ -4001,64 +4016,71 @@
 								ensure that all properties in the manifest get checked.</p>
 						</details>
 					</section>
-					
+
 					<section id="obtain-pub-resource-list">
 						<h4>Obtain a List of Unique Resources</h4>
-						
-						<p>To <dfn>obtain a list of unique resources</dfn> belonging to a <a>digital publication</a> from
-							its <var>readingOrder</var> and <var>resources</var>, run the following steps:</p>
-						
+
+						<p>To <dfn>obtain a list of unique resources</dfn> belonging to a <a>digital publication</a>
+							from its <var>readingOrder</var> and <var>resources</var>, run the following steps:</p>
+
 						<ol>
-							<li>
+							<li id="reslist-set-var">
 								<p>Let <var>uniqueResources</var> be an empty <a
-									href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a>.</p>
+										href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a>.</p>
 							</li>
-							<li>
+
+							<li id="reslist-readingorder">
 								<p><a href="https://infra.spec.whatwg.org/#set-iterate">For each</a>
-									<var>resource</var> of <var>readingOrder</var>, set <var>uniqueResources</var> to the
-									result of running <a>append URL</a> given <var>resource</var> and
-									<var>uniqueResources</var>.</p>
+									<var>resource</var> of <var>readingOrder</var>, set <var>uniqueResources</var> to
+									the result of running <a>append URL</a> given <var>resource</var> and
+										<var>uniqueResources</var>.</p>
 							</li>
-							<li>
+
+							<li id="reslist-resources">
 								<p><a href="https://infra.spec.whatwg.org/#set-iterate">For each</a>
 									<var>resource</var> of <var>resources</var>, set <var>uniqueResources</var> to the
 									result of running <a>append URL</a> given <var>resource</var> and
-									<var>uniqueResources</var>.</p>
+										<var>uniqueResources</var>.</p>
 							</li>
-							<li>
+
+							<li id="reslist-end">
 								<p>Return <var>uniqueResources</var>.</p>
 							</li>
 						</ol>
-						
+
 						<section id="append-url">
 							<h5>Append URL</h5>
-							
+
 							<p>To <dfn>append URL</dfn> of <a><code>LinkedResource</code></a>
-								<var>resource</var> to the set <var>uniqueResources</var>, run the following steps:</p>
-							
+								<var>resource</var> to the set <var>uniqueResources</var>, for the term <var>term</var>,
+								run the following steps:</p>
+
 							<ol>
-								<li>
+								<li id="append-parse-url">
 									<p>let <var>url</var> be the result of running the <a
-										href="https://url.spec.whatwg.org/#concept-url-serializer">URL
-										serializer</a>&#160;[[!url]] on <var>resource["url"]</var> with the <var>exclude
-											fragment flag</var> set.</p>
+											href="https://url.spec.whatwg.org/#concept-url-serializer">URL
+											serializer</a>&#160;[[!url]] on <var>resource["url"]</var> with the
+											<var>exclude fragment flag</var> set.</p>
 								</li>
-								<li>
-									<p><a href="https://infra.spec.whatwg.org/#set-append">append</a>
+								<li id="append-no-dupes">
+									<p>if <var>uniqueResources</var>
+										<a href="https://infra.spec.whatwg.org/#list-contain">contains</a>
+										<var>url</var>, <a>validation error</a>. Otherwise, <a
+											href="https://infra.spec.whatwg.org/#set-append">append</a>
 										<var>url</var> to <var>uniqueResources</var>.</p>
 								</li>
-								<li>
+								<li id="append-alternates">
 									<p>if <var>resource["alternate"]</var> is set, set <var>uniqueResources</var> to the
 										result of <a>append URL</a> given <var>resource["alternate"]</var> and
-										<var>uniqueResources</var>.</p>
+											<var>uniqueResources</var>.</p>
 								</li>
-								<li>
+								<li id="append-end">
 									<p>return <var>uniqueResources</var>.</p>
 								</li>
 							</ol>
 						</section>
 					</section>
-					
+
 					<section id="remove-empty-arrays">
 						<h4>Remove Empty Arrays</h4>
 
@@ -4066,11 +4088,12 @@
 							these steps:</p>
 
 						<ol>
-							<li>
+							<li id="array-empty">
 								<p>If <var>value</var> is an empty <a href="https://infra.spec.whatwg.org/#list"
 										>list</a>, return failure.</p>
 							</li>
-							<li>
+
+							<li id="array-children">
 								<p>Otherwise, if <var>value</var> is a <a
 										href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a
 										href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
@@ -4610,9 +4633,23 @@ dictionary LocalizableString {
 						href="https://www.w3.org/TR/html/grouping-content.html#the-ul-element"><code>ul</code></a>
 					element.</p>
 
-				<p>The following algorithm MUST be applied to a walk of a DOM subtree rooted at the first
-						<code>nav</code> element in document order with the <code>role</code> attribute value
-						<code>doc-toc</code>. All explanations are <em>informative</em>.</p>
+				<p>The following algorithm MUST be applied to a walk of a DOM subtree rooted at the table of contents
+					element determined as follows:</p>
+
+				<ol>
+					<li>
+						<p>if the <code>LinkedResource</code> that identifies the table of contents includes a fragment
+							identifier in its URL, the element referenced by the fragment identifier provided the
+							element has the <code>role</code> attribute value <code>doc-toc</code>.</p>
+					</li>
+					<li>
+						<p>otherwise, the first element in document order with the <code>role</code> attribute value
+								<code>doc-toc</code>.</p>
+					</li>
+				</ol>
+
+				<p>If a table of contents element is not found, the publication does not have a table of contents that
+					can be used for machine rendering purposes.</p>
 
 				<ol>
 					<li id="toc-initialize-toc">
@@ -4651,9 +4688,8 @@ dictionary LocalizableString {
 
 					<li id="toc-walk-dom">
 						<p>Walk over the DOM in <a href="https://www.w3.org/TR/html/infrastructure.html#tree-order">tree
-								order</a>, starting with the <code>nav</code> element the table of contents is being
-							built from, and trigger the first relevant step below for each element as the walk enters
-							and exits it.</p>
+								order</a>, starting with the element the table of contents is being built from, and
+							trigger the first relevant step below for each element as the walk enters and exits it.</p>
 						<ol>
 							<li id="toc-dom-enter-heading">
 								<p>

--- a/index.html
+++ b/index.html
@@ -3681,7 +3681,8 @@
 									<p>if <var>link["rel"]</var> is set and <a
 											href="https://infra.spec.whatwg.org/#list-contains">contains</a> any of the
 										values "<code>toc</code>", "<code>pagelist</code>" or "<code>cover</code>",
-											<a>validation error</a>, <a>remove</a>
+											<a>validation error</a>, <a
+											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 										<var>link</var> from <var>data["links"]</var>.</p>
 								</li>
 							</ol>

--- a/index.html
+++ b/index.html
@@ -3671,7 +3671,7 @@
 											fragment flag</var> set.</p>
 								</li>
 								<li>
-									<p>if <var>data["uniqueLinks"]</var>
+									<p>if <var>data["uniqueResources"]</var>
 										<a href="https://infra.spec.whatwg.org/#list-contain">contains</a>
 										<var>url</var>, <a>validation error</a>, <a
 											href="https://infra.spec.whatwg.org/#list-remove">remove</a>
@@ -4053,8 +4053,7 @@
 							<h5>Append URL</h5>
 
 							<p>To <dfn>append URL</dfn> of <a><code>LinkedResource</code></a>
-								<var>resource</var> to the set <var>uniqueResources</var>, for the term <var>term</var>,
-								run the following steps:</p>
+								<var>resource</var> to the set <var>uniqueResources</var>, run the following steps:</p>
 
 							<ol>
 								<li id="append-parse-url">
@@ -4071,9 +4070,11 @@
 										<var>url</var> to <var>uniqueResources</var>.</p>
 								</li>
 								<li id="append-alternates">
-									<p>if <var>resource["alternate"]</var> is set, set <var>uniqueResources</var> to the
-										result of <a>append URL</a> given <var>resource["alternate"]</var> and
-											<var>uniqueResources</var>.</p>
+									<p>if <var>resource["alternate"]</var> is set, <a
+											href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
+										<var>alternate</var> of <var>resource["alternate"]</var>, set
+											<var>uniqueResources</var> to the result of running <a>append URL</a> given
+											<var>alternate</var> and <var>uniqueResources</var>.</p>
 								</li>
 								<li id="append-end">
 									<p>return <var>uniqueResources</var>.</p>
@@ -4640,7 +4641,7 @@ dictionary LocalizableString {
 				<ol>
 					<li>
 						<p>if the <code>LinkedResource</code> that identifies the table of contents includes a fragment
-							identifier in its URL, the element referenced by the fragment identifier provided the
+							identifier in its URL, the element referenced by the fragment identifier, provided the
 							element has the <code>role</code> attribute value <code>doc-toc</code>.</p>
 					</li>
 					<li>

--- a/index.html
+++ b/index.html
@@ -2745,11 +2745,12 @@
 		<section id="publication-resources">
 			<h2>Publication Resources</h2>
 
-			<p>The list of resources belonging to a <a>digital publication</a> &#8212; its <a>bounds</a> &#8212; is
-				obtained from the union of resources listed in the <a href="#default-reading-order"
+			<p>The list of unique resources belonging to a <a>digital publication</a> &#8212; its <a>bounds</a> &#8212;
+				is obtained from the union of resources listed in the <a href="#default-reading-order"
 						><code>readingOrder</code></a> and <a href="#resource-list"><code>resources</code></a>,
 				including any <a href="#linkedresource-alternate"><code>alternate</code></a> resources. The process for
-				obtaining this list is described in <a href="#obtain-pub-resource-list"></a>.</p>
+					<a href="#validate-unique-resources">creating this list</a> is described in the manifest processing
+				algorithm.</p>
 
 			<p>All other resources are outside the bounds of the digital publication (e.g., resources listed in the
 						<a><code>links</code></a> section and hyperlinks in the content to external resources on the

--- a/index.html
+++ b/index.html
@@ -3623,38 +3623,35 @@
 									error</a>, set to "<code>ltr</code>".</p>
 						</li>
 
-						<li id="validate-resources">
-							<p>(<a href="#resource-list"></a>) If <var>data["resources"]</var> is set, let
-									<var>uniqueURLs</var> be an empty <a
-									href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a>. <a
-									href="https://infra.spec.whatwg.org/#list-iterate">For each</a>
-								<var>resource</var> of <var>data["resources"]</var>:</p>
+						<li id="validate-unique-resources">
+							<p>(<a href="#publication-resources"></a>) Obtain and verify the unique URLs within the
+								publication <a>bounds</a> as follows:</p>
 							<ol>
-								<li>
-									<p>let <var>url</var> be the result of running <a
-											href="https://url.spec.whatwg.org/#concept-url-serializer">URL
-											serializer</a>&#160;[[!url]] on <var>resource["url"]</var> with <var>exclude
-											fragment flag</var> set.</p>
+								<li id="reslist-readingorder">
+									<p>If <var>readingOrder</var> is set, let <var>readingOrderURLs</var> be the result
+										of running <a>get unique URLs</a> given <var>readingOrder</var>. Otherwise, let
+											<var>readingOrderURLs</var> be an empty <a
+											href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a>.</p>
 								</li>
-								<li>
-									<p>if <var>uniqueURLs</var>
-										<a href="https://infra.spec.whatwg.org/#list-contain">contains</a>
-										<var>url</var>, <a>validation error</a>.</p>
+
+								<li id="reslist-resources">
+									<p>If <var>resources</var> is set, let <var>resourcesURLs</var> be the result of
+										running <a>get unique URLs</a> given <var>resources</var>. Otherwise, let
+											<var>resourcesURLs</var> be an empty <a
+											href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a>.</p>
 								</li>
-								<li>
-									<p>otherwise, <a href="https://infra.spec.whatwg.org/#set-append">append</a>
-										<var>url</var> to <var>uniqueURLs</var></p>
+
+								<li id="reslist-end">
+									<p>Set <var>data['uniqueResources']</var> to the <a
+											href="https://infra.spec.whatwg.org/#set-union">union</a> of
+											<var>readingOrderURLs</var> and <var>resourceURLs</var>.</p>
 								</li>
 							</ol>
-						</li>
-
-						<li id="validate-unique-resources">
-							<p>(<a href="#publication-resources"></a>) Set <var>data["uniqueResources"]</var> to the
-								result of running <a>obtain a list of unique resources</a> given
-									<var>data["readingOrder"]</var> and <var>data["resources"]</var>.</p>
 							<details>
 								<summary>Explanation</summary>
-								<p>This step compiles a list of all the unique resources within the <a
+								<p>This step gets the list of unique URLs within the reading order and the resource
+									list. It then sets <var>data['uniqueResources']</var> the union of these two sets,
+									which represents the complete list of unique resources within the <a
 										href="#publication-resources">bounds of the publication</a>.</p>
 							</details>
 						</li>
@@ -4018,69 +4015,51 @@
 						</details>
 					</section>
 
-					<section id="obtain-pub-resource-list">
-						<h4>Obtain a List of Unique Resources</h4>
+					<section id="get-unique-urls">
+						<h4>Get Unique URLs</h4>
 
-						<p>To <dfn>obtain a list of unique resources</dfn> belonging to a <a>digital publication</a>
-							from its <var>readingOrder</var> and <var>resources</var>, run the following steps:</p>
+						<p>To <dfn>get unique URLs</dfn> from <var>resources</var>, run the following steps:</p>
 
 						<ol>
-							<li id="reslist-set-var">
-								<p>Let <var>uniqueResources</var> be an empty <a
+							<li id="unique-url-var">
+								<p>Let <var>uniqueURLs</var> be an empty <a
 										href="https://infra.spec.whatwg.org/#ordered-set">ordered set</a>.</p>
 							</li>
 
-							<li id="reslist-readingorder">
-								<p><a href="https://infra.spec.whatwg.org/#set-iterate">For each</a>
-									<var>resource</var> of <var>readingOrder</var>, set <var>uniqueResources</var> to
-									the result of running <a>append URL</a> given <var>resource</var> and
-										<var>uniqueResources</var>.</p>
+							<li id="unique-url-parse">
+								<p>For each <var>resource</var> of <var>resources</var>:</p>
+								<ol>
+									<li id="unique-parse-url">
+										<p>let <var>url</var> be the result of running <a
+												href="https://url.spec.whatwg.org/#concept-url-serializer">URL
+												serializer</a>&#160;[[!url]] on <var>resource["url"]</var> with
+												<var>exclude fragment flag</var> set.</p>
+									</li>
+
+									<li id="unique-parse-test">
+										<p>if <var>uniqueURLs</var>
+											<a href="https://infra.spec.whatwg.org/#list-contain">contains</a>
+											<var>url</var>, <a>validation error</a>.</p>
+									</li>
+
+									<li id="unique-parse-append">
+										<p>otherwise, <a href="https://infra.spec.whatwg.org/#set-append">append</a>
+											<var>url</var> to <var>uniqueURLs</var></p>
+									</li>
+								</ol>
 							</li>
 
-							<li id="reslist-resources">
-								<p><a href="https://infra.spec.whatwg.org/#set-iterate">For each</a>
-									<var>resource</var> of <var>resources</var>, set <var>uniqueResources</var> to the
-									result of running <a>append URL</a> given <var>resource</var> and
-										<var>uniqueResources</var>.</p>
-							</li>
-
-							<li id="reslist-end">
-								<p>Return <var>uniqueResources</var>.</p>
+							<li id="unique-url-end">
+								<p>return <var>uniqueURLs</var>.</p>
 							</li>
 						</ol>
 
-						<section id="append-url">
-							<h5>Append URL</h5>
-
-							<p>To <dfn>append URL</dfn> of <a><code>LinkedResource</code></a>
-								<var>resource</var> to the set <var>uniqueResources</var>, run the following steps:</p>
-
-							<ol>
-								<li id="append-parse-url">
-									<p>let <var>url</var> be the result of running the <a
-											href="https://url.spec.whatwg.org/#concept-url-serializer">URL
-											serializer</a>&#160;[[!url]] on <var>resource["url"]</var> with the
-											<var>exclude fragment flag</var> set.</p>
-								</li>
-								<li id="append-no-dupes">
-									<p>if <var>uniqueResources</var>
-										<a href="https://infra.spec.whatwg.org/#list-contain">contains</a>
-										<var>url</var>, <a>validation error</a>. Otherwise, <a
-											href="https://infra.spec.whatwg.org/#set-append">append</a>
-										<var>url</var> to <var>uniqueResources</var>.</p>
-								</li>
-								<li id="append-alternates">
-									<p>if <var>resource["alternate"]</var> is set, <a
-											href="https://infra.spec.whatwg.org/#list-iterate">for each</a>
-										<var>alternate</var> of <var>resource["alternate"]</var>, set
-											<var>uniqueResources</var> to the result of running <a>append URL</a> given
-											<var>alternate</var> and <var>uniqueResources</var>.</p>
-								</li>
-								<li id="append-end">
-									<p>return <var>uniqueResources</var>.</p>
-								</li>
-							</ol>
-						</section>
+						<details>
+							<summary>Explanation</summary>
+							<p>This function takes a list of <a><code>LinkedResource</code></a> objects &#8212; from
+								either the reading order or resource list &#8212; and returns the set of unique URLs. If
+								duplicates are encountered, warnings are issued.</p>
+						</details>
 					</section>
 
 					<section id="remove-empty-arrays">


### PR DESCRIPTION
These changes are in addition to the ones in PR #131. Breaking them out to make them easier to read, but will merge them before Monday's call.

- restore the restriction on duplicate resources in reading order, but only as recommendation so the entries are not removed;
- remove the restriction against fragment identifiers in the structural relations (toc, pagelist, cover);
- simplify the steps that reference all the unsupported data types for a value (simplifies to "if not a map ..." as the final step always expects a map);
- handle lists of URLs in the URL normalize step;
- warn but don't remove duplicate resources from reading order and resource list;
- remove links that specify relations that have to be in publication bounds from the links section;
- add item["type"] as the context when recursively calling the verify value function (fixes #136);
- add IDs to various steps that didn't have them for easier referencing;
- change use of "expected type" to "expected value category" to avoid any confusion with object types;
- move note that explanations are informative to the conformance section as it applies across the various algorithms;
- clarify the process for finding the toc with a fragment identifier - element referenced by a fragment identifier if it has role=doc-toc, otherwise first element with role=doc-toc, otherwise no machine toc;
- remove expectation of a `nav` element for the toc from the processing algorithm, as it's not a requirement.

I believe this addresses all the ongoing issues, but let me know if I've missed anything. It's getting to be quite the list. :)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/140.html" title="Last updated on Nov 1, 2019, 12:13 PM UTC (110c3f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/140/b76ef13...110c3f0.html" title="Last updated on Nov 1, 2019, 12:13 PM UTC (110c3f0)">Diff</a>