### PR TITLE
add warning if rel not set for links

### DIFF
--- a/index.html
+++ b/index.html
@@ -3689,9 +3689,14 @@
 										<var>link</var> from <var>data["links"]</var>, then <a
 											href="https://infra.spec.whatwg.org/#iteration-continue">continue</a>.</p>
 								</li>
+								<li id="links-check-rel">
+									<p>if <var>link["rel"]</var> is not set or is an empty <a
+											href="https://infra.spec.whatwg.org/#list">list</a>, <a>validation
+										error</a>.</p>
+								</li>
 								<li id="links-check-struct-rel">
-									<p>if <var>link["rel"]</var> is set and <a
-											href="https://infra.spec.whatwg.org/#list-contains">contains</a> any of the
+									<p>otherwise, if <var>link["rel"]</var>
+										<a href="https://infra.spec.whatwg.org/#list-contains">contains</a> any of the
 										values "<code>contents</code>", "<code>pagelist</code>" or "<code>cover</code>",
 											<a>validation error</a>, <a
 											href="https://infra.spec.whatwg.org/#list-remove">remove</a>


### PR DESCRIPTION
One last validation detail I noticed missing from the algorithm.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/151.html" title="Last updated on Nov 7, 2019, 6:04 PM UTC (4f9f2ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/151/809f4d0...4f9f2ff.html" title="Last updated on Nov 7, 2019, 6:04 PM UTC (4f9f2ff)">Diff</a>