### PR TITLE
Clarify default value processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2056,10 +2056,9 @@
 							</tbody>
 						</table>
 
-						<p id="generate_title">If a title is not included in the manifest, and a <a>digital
-								publication</a> does not define alternative rules for obtaining one, the user agent MUST
-							create one. This specification does not specify what heuristics to use to generate such a
-							title.</p>
+						<p id="generate_title">If a title is not included in the manifest, the user agent MUST create
+							one. The process for obtaining the title is defined in <a href="#add-default-values"
+							></a>.</p>
 
 						<p class="note">A user agent is not expected to produce a <a data-cite="wcag21#page-titled"
 								>meaningful title</a>&#160;[[wcag21]] for a publication when one is not specified. </p>
@@ -2145,7 +2144,12 @@
 							unexpected results in user agents (e.g., links to the resource might not resolve to the
 							right instance in the reading order).</p>
 
-						<p>The default reading order MUST include at least one resource.</p>
+						<p>The default reading order MUST include at least one resource after <a
+								href="#manifest-processing">processing of the manifest</a>. Depending on the <a
+								href="#manifest-discovery">discovery method</a> a <a>profile</a> uses, the default
+							reading order might not need to be explicitly specified in the manifest (i.e., a default
+							document might be automatically included). See <a href="#add-default-values"></a> for more
+							information.</p>
 
 						<pre class="example" title="Expressing the reading order as a simple list of URLs.">{
     …
@@ -3065,13 +3069,13 @@
 					</li>
 
 					<li id="processing-defaults">
-						<p>Set <var>processed</var> to the result of running <a>add HTML defaults</a>, when successful,
-							given <var>processed</var> and <var>document</var>. Otherwise, terminate processing, return
-							failure.</p>
+						<p>Set <var>processed</var> to the result of running <a>add defaults values</a>, when
+							successful, given <var>processed</var> and <var>document</var>, when specified. Otherwise,
+							terminate processing, return failure.</p>
 						<details>
 							<summary>Explanation</summary>
 							<p>This step checks if any information missing from the manifest can be obtained from the
-								HTML document that links to the manifest (e.g., the title and reading order).</p>
+								HTML document that links to the document, or from other sources.</p>
 						</details>
 					</li>
 
@@ -4203,13 +4207,13 @@
 					</section>
 				</section>
 
-				<section id="add-html-defaults">
-					<h3>Add HTML Defaults</h3>
+				<section id="add-default-values">
+					<h3>Add Default Values</h3>
 
-					<p>To <dfn>add HTML defaults</dfn> for missing properties in <a
+					<p>To <dfn>add default values</dfn> for missing properties in <a
 							href="https://infra.spec.whatwg.org/#ordered-map">map</a>
-						<var>data</var> with an <a data-cite="html#the-document-object">HTML Document (DOM)
-						Node</a>&#160;[[!html]] <var>document</var>, run the following steps:</p>
+						<var>data</var> with an optional <a data-cite="html#the-document-object">HTML Document (DOM)
+							Node</a>&#160;[[!html]] <var>document</var>, run the following steps:</p>
 
 					<ol>
 						<li id="processing-defaults-title">
@@ -4222,9 +4226,10 @@
 										follows:</p>
 									<ul>
 										<li>
-											<p>if the <a data-cite="html#the-title-element"><code>title</code></a>
-												element&#160;[[!html]] of <var>document</var> is set and its contains is
-												not empty, set <var>title["value"]</var> to the text content of the
+											<p>if <var>document</var> is set, if the <a
+													data-cite="html#the-title-element"><code>title</code></a>
+												element&#160;[[!html]] of <var>document</var> is set and is not empty,
+												set <var>title["value"]</var> to the text content of the
 													<code>title</code> element.</p>
 											<p>Set <var>title["language"]</var> to the <a
 													data-cite="html#the-lang-and-xml:lang-attributes"
@@ -4280,8 +4285,9 @@
 									href="https://infra.spec.whatwg.org/#list">list</a>:</p>
 							<ul>
 								<li>
-									<p>if <a data-cite="!dom#concept-document-url">document.URL</a> is not set, this is
-										a <a>fatal error</a>. Return failure.</p>
+									<p>if either <var>document</var> or <a data-cite="!dom#concept-document-url"
+											>document.URL</a> are not set, this is a <a>fatal error</a>. Return
+										failure.</p>
 								</li>
 								<li>
 									<p>set <var>data["readingOrder"]</var> to an empty <a
@@ -4306,8 +4312,8 @@
 						</li>
 
 						<li id="processing-defaults-extension">
-							<p>If a <a>profile</a> specifies <var>document</var> fallbacks, those steps are executed at
-								this point.</p>
+							<p>If a <a>profile</a> specifies default values the user agent has to generate, those steps
+								are executed at this point.</p>
 						</li>
 
 						<li>


### PR DESCRIPTION
This PR addresses #155 as follows:

- expands on title and reading order to clarify that user agent data harvesting occurs when not specified
- changes the name of "add html defaults" to "add default values" and makes the html document optional

Making the html doc optional allows, for example, for the title to be generated regardless of whether there is a linking document (i.e., processing falls through to the UA having to generate a title). It also makes the function more versatile in case other situations like this arise where you either get something from the html doc or have to generate.

It also doesn't greatly change what we already had, which is always nice.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/157.html" title="Last updated on Nov 8, 2019, 3:38 PM UTC (3c3379b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/157/7a75b1c...3c3379b.html" title="Last updated on Nov 8, 2019, 3:38 PM UTC (3c3379b)">Diff</a>