### PR TITLE
switch length to duration for LinkedResource

### DIFF
--- a/experiments/audiobook/flatland-canonical.json
+++ b/experiments/audiobook/flatland-canonical.json
@@ -66,7 +66,7 @@
     {
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_1_abbott.mp3", 
       "encodingFormat": "audio/mpeg", 
-      "length": 1371,
+      "duration": "PT1371S",
       "name": [
         {
           "value": "Part 1, Sections 1 - 3",
@@ -77,7 +77,7 @@
     {
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_2_abbott.mp3", 
       "encodingFormat": "audio/mpeg", 
-      "length": 1669,
+      "duration": "PT1669S",
       "name": [
         {
           "value": "Part 1, Sections 4 - 5",
@@ -88,7 +88,7 @@
     {
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_3_abbott.mp3", 
       "encodingFormat": "audio/mpeg", 
-      "length": 1506,
+      "duration": "PT1506S",
       "name": [
         {
           "value": "Part 1, Sections 6 - 7",
@@ -99,7 +99,7 @@
     {
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_4_abbott.mp3", 
       "encodingFormat": "audio/mpeg", 
-      "length": 1798,
+      "duration": "PT1798S",
       "name": [
         {
           "value": "Part 1, Sections 8 - 10",
@@ -110,7 +110,7 @@
     {
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_5_abbott.mp3", 
       "encodingFormat": "audio/mpeg", 
-      "length": 1225,
+      "duration": "PT1225S",
       "name": [
         {
           "value": "Part 1, Sections 11 - 12",
@@ -121,7 +121,7 @@
     {
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_6_abbott.mp3", 
       "encodingFormat": "audio/mpeg", 
-      "length": 1659,
+      "duration": "PT1659S",
       "name": [
         {
           "value": "Part 2, Sections 13 - 14",
@@ -132,7 +132,7 @@
     {
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_7_abbott.mp3", 
       "encodingFormat": "audio/mpeg", 
-      "length": 2086,
+      "duration": "PT2086S",
       "name": [
         {
           "value": "Part 2, Sections 15 - 17",
@@ -143,7 +143,7 @@
     {
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_8_abbott.mp3", 
       "encodingFormat": "audio/mpeg", 
-      "length": 2662,
+      "duration": "PT2662S",
       "name": [
         {
           "value": "Part 2, Sections 18 - 20",
@@ -154,7 +154,7 @@
     {
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_9_abbott.mp3", 
       "encodingFormat": "audio/mpeg", 
-      "length": 1177,
+      "duration": "PT1177S",
       "name": [
         {
           "value": "Part 2, Sections 21 - 22",

--- a/experiments/audiobook/flatland.json
+++ b/experiments/audiobook/flatland.json
@@ -34,47 +34,47 @@
     {
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_1_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "length": 1371,
+      "duration": "PT1371S",
       "name": "Part 1, Sections 1 - 3"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_2_abbott.mp3",
       "encodingFormat": "audio/mpeg", 
-      "length": 1669,
+      "duration": "PT1669S",
       "name": "Part 1, Sections 4 - 5"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_3_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "length": 1506,
+      "duration": "PT1506S",
       "name": "Part 1, Sections 6 - 7"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_4_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "length": 1669,
+      "duration": "PT1669S",
       "name": "Part 1, Sections 8 - 10"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_5_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "length": 1506,
+      "duration": "PT1506S",
       "name": "Part 1, Sections 11 - 12"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_6_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "length": 1798,
+      "duration": "PT1798S",
       "name": "Part 2, Sections 13 - 14"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_7_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "length": 1225,
+      "duration": "PT1225S",
       "name": "Part 2, Sections 15 - 17"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_8_abbott.mp3",
       "encodingFormat": "audio/mpeg",
-      "length": 1371,
+      "duration": "PT1371S",
       "name": "Part 2, Sections 18 - 20"
     },{
       "url": "http://www.archive.org/download/flatland_rg_librivox/flatland_9_abbott.mp3", 
       "encodingFormat": "audio/mpeg",
-      "length": 1659,
+      "duration": "PT1659S",
       "name": "Part 2, Sections 21 - 22"
     }
   ]

--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
 
 				<p>Manifest properties, in particular those categorized as <a href="#descriptive-properties">descriptive
 						properties</a>, are primarily drawn from <a href="https://schema.org">Schema.org</a> and its <a
-						href="https://schema.org/docs/schemas.html">hosted extensions</a>&#160;[[!schema.org]]. As a
+						href="https://schema.org/docs/schemas.html">hosted extensions</a>&#160;[[schema.org]]. As a
 					consequence, these properties inherit their syntax and semantics from Schema.org, making manifest
 					authoring compatible with Schema.org authoring.</p>
 
@@ -207,7 +207,7 @@
 						href="#publication-types">type of publication</a> specified in the manifest. Properties are
 					often available in many Schema.org types, as a result of the inheritance model used by the
 					vocabulary, but not all properties are available for all types. For more detailed information about
-					which types accept which properties, refer to [[!schema.org]].</p>
+					which types accept which properties, refer to [[schema.org]].</p>
 
 				<p>More information about using additional Schema.org properties is also available in <a
 						href="#publication-types"></a> and <a href="#extensibility-manifest-properties"></a></p>

--- a/index.html
+++ b/index.html
@@ -732,16 +732,17 @@
 									<td>(None)</td>
 								</tr>
 								<tr>
-									<td id="linkedresource-length">
-										<code>length</code>
+									<td id="linkedresource-duration">
+										<code>duration</code>
 									</td>
-									<td>The total length of a time-based media resource in (possibly fractional)
-										seconds. OPTIONAL</td>
-									<td>Number</td>
+									<td>Overall duration of a time-based media resource. OPTIONAL</td>
+									<td>Duration value as defined by&#160;[[!iso8601]].</td>
 									<td>
-										<a href="#value-number">Number</a>
+										<a href="#value-literal">Literal</a>
 									</td>
-									<td>(None)</td>
+									<td>
+										<a href="https://schema.org/duration"><code>duration</code></a> (<a
+											href="https://schema.org/Property">Property</a>) </td>
 								</tr>
 								<tr>
 									<td id="linkedresource-alternate">
@@ -804,7 +805,7 @@
             "type": "LinkedResource",
             "url": "chapter1.json",
             "encodingFormat": "application/vnd.wp-sync-media+json",
-            "length": 1669
+            "duration": "PT1669S"
         }
     ]
 }</pre>
@@ -3956,10 +3957,11 @@
 											>continue</a>.</p>
 									</li>
 									<li>
-										<p>if <a href="#linkedresource-length"><var>resource["length"]</var></a> is set
-											and is not a number, or is a negative number, <a>validation error</a>, <a
-												href="https://infra.spec.whatwg.org/#map-remove">remove</a>
-											<var>resource["length"]</var>.</p>
+										<p>if <a href="#linkedresource-duration"><var>resource["duration"]</var></a> is
+											set and is not a valid duration value, per&#160;[[!iso8601]], <a>validation
+												error</a>, <a href="https://infra.spec.whatwg.org/#map-remove"
+												>remove</a>
+											<var>resource["duration"]</var>.</p>
 									</li>
 								</ul>
 								<details>
@@ -3969,8 +3971,8 @@
 									<ol>
 										<li>If a URL is not specified, or is invalid, the <code>LinkedResource</code> is
 											removed.</li>
-										<li>If the length of the resource is specified, and is not a positive number,
-											the length is removed.</li>
+										<li>If the duration of the resource is specified, or is not a value ISO 8601
+											duration value, the duration property is removed.</li>
 									</ol>
 								</details>
 							</li>
@@ -4430,7 +4432,7 @@ dictionary LinkedResource {
              sequence&lt;LocalizableString> description;
              sequence&lt;DOMString>         rel;
              DOMString                   integrity;
-             double                      length;
+             DOMString                   duration;
              sequence&lt;LinkedResource>    alternate;
 };</pre>
 					</section>

--- a/schema/link.schema.json
+++ b/schema/link.schema.json
@@ -52,9 +52,9 @@
         "integrity": {
             "type": "string"
         },
-        "length": {
-            "type": "number",
-            "exclusiveMinimum": 0
+        "duration": {
+            "type": "string",
+            "pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"
         },
         "alternate": {
             "type": "array",


### PR DESCRIPTION
Harmonizes so we don't have two properties for the same purpose with different names and different valid values.

https://github.com/w3c/audiobooks/issues/42


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/164.html" title="Last updated on Nov 13, 2019, 12:51 AM UTC (35cd46f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/164/59baa51...35cd46f.html" title="Last updated on Nov 13, 2019, 12:51 AM UTC (35cd46f)">Diff</a>