### PR TITLE
Prioritize extension validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3558,6 +3558,16 @@
 							</details>
 						</li>
 
+						<li id="validate-extension">
+							<p>If a <a>profile</a> specifies data validation checks, those steps are executed at this
+								point.</p>
+							<details>
+								<summary>Explanation</summary>
+								<p>Profile validation steps are prioritized over the default steps so that if profiles
+									have, for example, different default values to apply, those values get applied.</p>
+							</details>
+						</li>
+
 						<li id="validate-type">
 							<p>(<a href="#publication-types"></a>) If <var>data["type"]</var> is not set or is an empty
 									<a href="https://infra.spec.whatwg.org/#list">list</a>, <a>validation error</a>, set
@@ -3760,11 +3770,6 @@
 								<p>For covers, it also checks that a name has been set on image-based formats for
 									accessibility purposes.</p>
 							</details>
-						</li>
-
-						<li id="validate-extension">
-							<p>If a <a>profile</a> specifies data validation checks, those steps are executed at this
-								point.</p>
 						</li>
 
 						<li id="validate-empty-arrays">


### PR DESCRIPTION
Whether or not https://github.com/w3c/audiobooks/issues/48 results in a change, profile validation/defaults should be prioritized over the general manifest rules.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/165.html" title="Last updated on Nov 13, 2019, 4:16 PM UTC (aaa8873)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/165/f51698d...aaa8873.html" title="Last updated on Nov 13, 2019, 4:16 PM UTC (aaa8873)">Diff</a>