### PR TITLE
Correct flatland manifest

### DIFF
--- a/experiments/audiobook/flatland.json
+++ b/experiments/audiobook/flatland.json
@@ -27,6 +27,7 @@
   "accessibilityFeature": ["readingOrder", "unlocked"],
   "accessibilityHazard": "noSoundHazard",
   "accessibilitySummary": "This is just a test summary",
+  "readingProgression": "ltr",
   "resources": [
     {
       "rel": "cover",

--- a/experiments/audiobook/flatland.json
+++ b/experiments/audiobook/flatland.json
@@ -18,10 +18,10 @@
   "duration": "PT13774S",
   "license": "https://creativecommons.org/publicdomain/zero/1.0/",
   "abridged": false,
-  "accessMode": "audio",
+  "accessMode": "auditory",
   "accessModeSufficient": [{
       "type": "ItemList",
-      "itemListElement": ["audio"],
+      "itemListElement": ["auditory"],
       "description": "Audio"
   }],
   "accessibilityFeature": ["readingOrder", "unlocked"],

--- a/experiments/audiobook/flatland.json
+++ b/experiments/audiobook/flatland.json
@@ -4,29 +4,47 @@
       "https://www.w3.org/ns/pub-context",
       {"language": "en"}
   ],
-  "conformsTo": "https://www.w3.org/TR/audiobooks",
+  "conformsTo": "https://www.w3.org/TR/audiobooks/",
   "type": "Audiobook",
   "id": "https://librivox.org/flatland-a-romance-of-many-dimensions-by-edwin-abbott-abbott/",
-  "url": "https://w3c.github.io/wpub/experiments/audiobook/",
+  "url": "https://w3c.github.io/pub-manifest/experiments/audiobook/",
   "name": "Flatland: A Romance of Many Dimensions",
   "author": "Edwin Abbott Abbott",
   "readBy": "Ruth Golding",
   "publisher": "Librivox",
   "inLanguage": "en",
-  "dateModified": "2018-06-14T19:32:18Z",
+  "dateModified": "2019-11-14",
   "datePublished": "2008-10-12",
-  "duration": "PT15153S",
+  "duration": "PT13774S",
   "license": "https://creativecommons.org/publicdomain/zero/1.0/",
-
+  "abridged": false,
+  "accessMode": "audio",
+  "accessModeSufficient": [{
+      "type": "ItemList",
+      "itemListElement": ["audio"],
+      "description": "Audio"
+  }],
+  "accessibilityFeature": ["readingOrder", "unlocked"],
+  "accessibilityHazard": "noSoundHazard",
+  "accessibilitySummary": "This is just a test summary",
   "resources": [
     {
       "rel": "cover",
       "url": "http://ia800704.us.archive.org/9/items/LibrivoxCdCoverArt12/Flatland_1109.jpg",
-      "encodingFormat": "image/jpeg"
+      "encodingFormat": "image/jpeg",
+      "name": "Cover page with title and author"
     },{
-      "rel": "contents", 
-      "url": "toc.html", 
+      "rel": "contents",
+      "url": "toc.html",
       "encodingFormat": "text/html"
+    },{
+        "rel": "accessibility-report",
+        "url": "a11y.html",
+        "encodingFormat": "text/html"
+    },{
+        "rel": "privacy-policy,",
+        "url": "privacy.html",
+        "encodingFormat": "text/html"
     }
   ],
 


### PR DESCRIPTION
This is to handle https://github.com/w3c/audiobooks/issues/50. The version in the PR is checked by my "validator" (provided my code is correct:-).

fix https://github.com/w3c/audiobooks/issues/50

I am not sure about the values/meanings of the accessibility term, they should at least be correct... Please check.