### PR TITLE
get rid of boolean flagging in rel checks

### DIFF
--- a/index.html
+++ b/index.html
@@ -3709,64 +3709,44 @@
 						<li id="validate-structural-relations">
 							<p>(<a href="#structural-rel"></a>) Verify the use of structural relations as follows:</p>
 							<ol>
-								<li id="rel-booleans">
-									<p>Let <var>contents</var>, <var>pagelist</var> and <var>cover</var> be <a
-											href="https://infra.spec.whatwg.org/#boolean">boolean</a> values set to
-										false.</p>
-								</li>
 								<li id="rel-create-list">
 									<p>Set <var>resources</var> to the value of <var>data["readingOrder"]</var>, when
 										defined, otherwise to an empty <a href="https://infra.spec.whatwg.org/#list"
 											>list</a>. <a href="https://infra.spec.whatwg.org/#list-extend">Extend</a>
 										<var>resources</var> with <var>data["resources"]</var>, when defined.</p>
 								</li>
-								<li id="rel-iterate-list">
-									<p><a href="https://infra.spec.whatwg.org/#list-iterate">For each</a>
-										<var>resource</var> of <var>resources</var>, if <var>resource["rel"]</var> is
-										set:</p>
-									<ol>
-										<li id="rel-check-contents">
-											<p>If <var>resource["rel"]</var>
-												<a href="https://infra.spec.whatwg.org/#list-contain">contains</a> the
-												value "<code>contents</code>": if <var>contents</var> is
-													<code>true</code>, <a>validation error</a>; otherwise, set
-													<var>contents</var> to <code>true</code>.</p>
-										</li>
-										<li id="rel-check-pagelist">
-											<p>If <var>resource["rel"]</var>
-												<a href="https://infra.spec.whatwg.org/#list-contain">contains</a> the
-												value "<code>pagelist</code>": if <var>pagelist</var> is
-													<code>true</code>, <a>validation error</a>; otherwise, set
-													<var>pagelist</var> to <code>true</code>.</p>
-										</li>
-										<li id="rel-compile-covers">
-											<p>If <var>resource["rel"]</var>
-												<a href="https://infra.spec.whatwg.org/#list-contain">contains</a> the
-												value "<code>cover</code>":</p>
-											<ol>
-												<li>
-													<p>if <var>cover</var> is <code>true</code>, <a>validation
-														error</a>.</p>
-												</li>
-												<li>
-													<p>otherwise, set <var>cover</var> to <code>true</code>. If
-															<var>resource["encodingFormat"]</var> is set and specifies
-														an image media type (<code>image/*</code>), and
-															<var>resource["name"]</var> is not set, <a>validation
-															error</a>.</p>
-												</li>
-											</ol>
-										</li>
-
-									</ol>
+								<li id="rel-check-contents">
+									<p>If more than one <a href="https://infra.spec.whatwg.org/#list-item">item</a> in
+											<var>resources</var> has a <var>rel</var>
+										<a href="https://infra.spec.whatwg.org/#map-entry">entry</a> that <a
+											href="https://infra.spec.whatwg.org/#list-contain">contains</a> the value
+											"<code>contents</code>", <a>validation error</a>.</p>
+								</li>
+								<li id="rel-check-pagelist">
+									<p>If more than one <a href="https://infra.spec.whatwg.org/#list-item">item</a> in
+											<var>resources</var> has a <var>rel</var>
+										<a href="https://infra.spec.whatwg.org/#map-entry">entry</a> that <a
+											href="https://infra.spec.whatwg.org/#list-contain">contains</a> the value
+											"<code>pagelist</code>", <a>validation error</a>.</p>
+								</li>
+								<li id="rel-check-covers">
+									<p>If more than one <a href="https://infra.spec.whatwg.org/#list-item">item</a> in
+											<var>resources</var> has a <var>rel</var>
+										<a href="https://infra.spec.whatwg.org/#map-entry">entry</a> that <a
+											href="https://infra.spec.whatwg.org/#list-contain">contains</a> the value
+											"<code>cover</code>", <a>validation error</a>.</p>
+									<p>If the cover(s) have an <var>encodingFormat</var>
+										<a href="https://infra.spec.whatwg.org/#map-entry">entry</a> that specifies an
+										image media type (<code>image/*</code>), and do not have a <var>name</var>
+										<a href="https://infra.spec.whatwg.org/#map-entry">entry</a>, <a>validation
+											error</a>.</p>
 								</li>
 							</ol>
 							<details>
 								<summary>Explanation</summary>
-								<p>This step iterates over all the resources specified in the reading order and resource
-									list and verifies that only one instance of a table of content, page list and cover
-									have been specified. If additional resources are found with one of these relations,
-									a warning is raised.</p>
+								<p>This checks the resources specified in the reading order and resource list to verify
+									that only one instance of a table of content, page list and cover have been
+									specified.</p>
 								<p>For covers, it also checks that a name has been set on image-based formats for
 									accessibility purposes.</p>
 							</details>


### PR DESCRIPTION
I noticed yesterday with audiobooks that using boolean flags is getting a bit too programming level specific for the algorithms, so I went back to remove them from the manifest rel checks, too.

This PR doesn't change the outcome of the step, but maybe makes it a bit clearer what we're checking for without getting into the details of how to do it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/167.html" title="Last updated on Nov 16, 2019, 2:04 PM UTC (118b624)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/167/d8d49c4...118b624.html" title="Last updated on Nov 16, 2019, 2:04 PM UTC (118b624)">Diff</a>