### PR TITLE
Fix encoding format for "alternate" example

### DIFF
--- a/index.html
+++ b/index.html
@@ -806,7 +806,7 @@
         {
             "type": "LinkedResource",
             "url": "chapter1.json",
-            "encodingFormat": "application/vnd.wp-sync-media+json",
+            "encodingFormat": "application/vnd.syncnarr+json",
             "duration": "PT1669S"
         }
     ]


### PR DESCRIPTION
Although there's no explicit reference to Synchronized Narration in this section, example #6 uses it to show how the 'alternate' property works. This is a correction to the encoding format used in that example, to align with the current draft of Synchronized Narration.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marisademeglio/pub-manifest/pull/172.html" title="Last updated on Nov 28, 2019, 6:49 PM UTC (41653af)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/172/ae9d535...marisademeglio:41653af.html" title="Last updated on Nov 28, 2019, 6:49 PM UTC (41653af)">Diff</a>