### PR TITLE
Minor updates on #180

### DIFF
--- a/index.html
+++ b/index.html
@@ -4838,7 +4838,7 @@ dictionary LocalizableString {
 											whitespace), set <var>toc["name"]</var> either to a placeholder value or to
 												<a href="https://infra.spec.whatwg.org/#nulls">null</a>.</p>
 									</li>
-									<li>Omit the element and continue processing with the next element.</li>
+									<li>Skip further processing of the element and continue to the next.</li>
 								</ol>
 								<details>
 									<summary>Explanation</summary>
@@ -4885,8 +4885,7 @@ dictionary LocalizableString {
 										<ol>
 											<li>If <var>current_toc_branch["entries"]</var> is <a
 													href="https://infra.spec.whatwg.org/#nulls">null</a> or a non-empty
-													<a href="https://infra.spec.whatwg.org/#list">list</a>, omit the
-												element and continue processing with the next element.</li>
+													<a href="https://infra.spec.whatwg.org/#list">list</a>, skip further processing of the element and continue to the next.</li>
 											<li>Otherwise, <a href="https://infra.spec.whatwg.org/#stack-push">push</a>
 												<var>current_toc_branch</var> onto <var>branches</var> and then set
 													<var>current_toc_branch</var> to <a
@@ -4898,8 +4897,7 @@ dictionary LocalizableString {
 										<ol>
 											<li>If <var>toc["entries"]</var> is <a
 													href="https://infra.spec.whatwg.org/#nulls">null</a> or a non-empty
-													<a href="https://infra.spec.whatwg.org/#list">list</a>, omit the
-												element and continue processing with the next element.</li>
+													<a href="https://infra.spec.whatwg.org/#list">list</a>, skip further processing of the element and continue to the next.</li>
 											<li>Otherwise, do nothing.</li>
 										</ol>
 									</li>
@@ -5116,7 +5114,7 @@ dictionary LocalizableString {
 												Otherwise, set <var>current_toc_branch["rel"]</var> to <a
 													href="https://infra.spec.whatwg.org/#nulls">null</a>.</li>
 										</ol>
-										<p>Omit the element and continue processing with the next element.</p>
+										<p>Skip further processing of the element and continue to the next.</p>
 									</li>
 								</ol>
 								<details>
@@ -5157,7 +5155,7 @@ dictionary LocalizableString {
 											href="https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute"
 											>hidden</a> attribute:</strong>
 								</p>
-								<p>Omit the element and continue processing with the next element.</p>
+								<p>Skip further processing of the element and continue to the next.</p>
 								<details>
 									<summary>Explanation</summary>
 									<p>As sectioning and sectioning root elements can define their own outlines,

--- a/index.html
+++ b/index.html
@@ -5204,7 +5204,7 @@ dictionary LocalizableString {
 				<ul>
 					<li>xx-Dec-2019: The table of contents processing algorithm has been updated to fix several bugs and editorial issues in
 						the expected outcomes. See issues <a href="https://github.com/w3c/pub-manifest/issues/177"
-							>177</a> and <a href="https://github.com/w3c/pub-manifest/issues/179">179</a>, as well as pull requests <a href="https://github.com/w3c/pub-manifest/pull/180">180</a> and <a href="https://github.com/w3c/pub-manifest/pull/181">181</a> for more
+							>177</a> and <a href="https://github.com/w3c/pub-manifest/issues/179">179</a>, as well as pull requests <a href="https://github.com/w3c/pub-manifest/pull/180">180</a> and <a href="https://github.com/w3c/pub-manifest/pull/182">182</a> for more
 						details.</li>
 				</ul>
 			</section>

--- a/index.html
+++ b/index.html
@@ -4741,6 +4741,9 @@ dictionary LocalizableString {
 					some steps, user agents are provided a choice in how to process the content to provide flexibility
 					for different presentation models.</p>
 
+				<p class="note">This algorithm is not defined in purely event driven terms, as inspecting all descendant nodes is not always necessary to obtain the needed information from the DOM. In some cases, an element, and all its descendants, is omitted immediately after it is processed on <em>enter</em>. An event approach could be applied, but would require modifying the algorithm to process/ignore the omitted nodes.</p>
+	
+	
 				<p class="note">User agents can process and internalize the resulting structure in whatever language and
 					form is appropriate.</p>
 
@@ -4768,11 +4771,6 @@ dictionary LocalizableString {
 
 				<p>If a table of contents element is not found, the publication does not have a table of contents that
 					can be used for machine rendering purposes.</p>
-
-				<p class="note">This algorithm is not defined in purely event driven terms, as inspecting all descendant
-					nodes is not necessary to obtain the needed information from the DOM. In some cases, an element is
-					exited immediately after it is processed. An event approach could be applied, but would require
-					modifying the algorithm to process/ignore the omitted nodes.</p>
 
 				<ol>
 					<li id="toc-initialize-toc">
@@ -4840,7 +4838,7 @@ dictionary LocalizableString {
 											whitespace), set <var>toc["name"]</var> either to a placeholder value or to
 												<a href="https://infra.spec.whatwg.org/#nulls">null</a>.</p>
 									</li>
-									<li>Exit the element and continue processing with the next element.</li>
+									<li>Omit the element and continue processing with the next element.</li>
 								</ol>
 								<details>
 									<summary>Explanation</summary>
@@ -4887,7 +4885,7 @@ dictionary LocalizableString {
 										<ol>
 											<li>If <var>current_toc_branch["entries"]</var> is <a
 													href="https://infra.spec.whatwg.org/#nulls">null</a> or a non-empty
-													<a href="https://infra.spec.whatwg.org/#list">list</a>, exit the
+													<a href="https://infra.spec.whatwg.org/#list">list</a>, omit the
 												element and continue processing with the next element.</li>
 											<li>Otherwise, <a href="https://infra.spec.whatwg.org/#stack-push">push</a>
 												<var>current_toc_branch</var> onto <var>branches</var> and then set
@@ -4900,7 +4898,7 @@ dictionary LocalizableString {
 										<ol>
 											<li>If <var>toc["entries"]</var> is <a
 													href="https://infra.spec.whatwg.org/#nulls">null</a> or a non-empty
-													<a href="https://infra.spec.whatwg.org/#list">list</a>, exit the
+													<a href="https://infra.spec.whatwg.org/#list">list</a>, omit the
 												element and continue processing with the next element.</li>
 											<li>Otherwise, do nothing.</li>
 										</ol>
@@ -4961,7 +4959,7 @@ dictionary LocalizableString {
     "name" → "",
     "url"  → "",
     "type" → "",
-    "rel"  → "",
+    "rel"  → null,
     "entries" → « »
 ]»</pre>
 								<details>
@@ -5118,7 +5116,7 @@ dictionary LocalizableString {
 												Otherwise, set <var>current_toc_branch["rel"]</var> to <a
 													href="https://infra.spec.whatwg.org/#nulls">null</a>.</li>
 										</ol>
-										<p>Exit the element and continue processing with the next element.</p>
+										<p>Omit the element and continue processing with the next element.</p>
 									</li>
 								</ol>
 								<details>
@@ -5159,7 +5157,7 @@ dictionary LocalizableString {
 											href="https://html.spec.whatwg.org/multipage/interaction.html#the-hidden-attribute"
 											>hidden</a> attribute:</strong>
 								</p>
-								<p>Exit the element and continue processing with the next element.</p>
+								<p>Omit the element and continue processing with the next element.</p>
 								<details>
 									<summary>Explanation</summary>
 									<p>As sectioning and sectioning root elements can define their own outlines,
@@ -5204,9 +5202,9 @@ dictionary LocalizableString {
 			<section>
 				<h3>Changes since Candidate Recommendation</h3>
 				<ul>
-					<li>xx-Dec-2019: The table of contents processing algorithm has been updated to fix several bugs in
+					<li>xx-Dec-2019: The table of contents processing algorithm has been updated to fix several bugs and editorial issues in
 						the expected outcomes. See issues <a href="https://github.com/w3c/pub-manifest/issues/177"
-							>177</a> and <a href="https://github.com/w3c/pub-manifest/issues/179">179</a> for more
+							>177</a> and <a href="https://github.com/w3c/pub-manifest/issues/179">179</a>, as well as pull requests <a href="https://github.com/w3c/pub-manifest/pull/180">180</a> and <a href="https://github.com/w3c/pub-manifest/pull/181">181</a> for more
 						details.</li>
 				</ul>
 			</section>


### PR DESCRIPTION
- took care of https://github.com/w3c/pub-manifest/pull/180#discussion_r357962658 and https://github.com/w3c/pub-manifest/pull/180#discussion_r357962970
- to handle the issue https://github.com/w3c/pub-manifest/pull/180#issuecomment-567124310 I exchanged the word 'exit' in the relevant sentences to 'omit', with a further clarification in the initial note


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/182.html" title="Last updated on Jan 8, 2020, 10:46 AM UTC (463c46f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/182/125f6ac...463c46f.html" title="Last updated on Jan 8, 2020, 10:46 AM UTC (463c46f)">Diff</a>