### PR TITLE
Added an extension point for profiles in the TOC file localization

### DIFF
--- a/index.html
+++ b/index.html
@@ -4741,8 +4741,7 @@ dictionary LocalizableString {
 					some steps, user agents are provided a choice in how to process the content to provide flexibility
 					for different presentation models.</p>
 
-				<p class="note">User agents can process and internalize the resulting structure in whatever language and
-					form is appropriate.</p>
+				<p class="note">User agents can process and internalize the resulting structure in whatever language and form is appropriate.</p>
 
 				<p>For the purposes of this algorithm, a <dfn>list element</dfn> is defined as either an
 						[[!html]]&#160;<a
@@ -4765,6 +4764,8 @@ dictionary LocalizableString {
 								<code>doc-toc</code>.</p>
 					</li>
 				</ol>
+
+				<p>The algorithm to locate the table of content element is executed on the structural resource defined in <a href="#pub-table-of-contents"></a>. A <a>profile</a> may also specify other possible resources.</p>
 
 				<p>If a table of contents element is not found, the publication does not have a table of contents that
 					can be used for machine rendering purposes.</p>


### PR DESCRIPTION
This is relevant to settle: https://github.com/w3c/audiobooks/issues/63.

---

Note that, if merged, the change section should be added. I did not do it here, because it would lead to merge conflicts with #180...


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/183.html" title="Last updated on Jan 27, 2020, 12:05 PM UTC (c047dcb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/183/aa1f795...c047dcb.html" title="Last updated on Jan 27, 2020, 12:05 PM UTC (c047dcb)">Diff</a>