### PR TITLE
Stupid cut-and-paste error on the IANA section

### DIFF
--- a/index.html
+++ b/index.html
@@ -5192,7 +5192,7 @@ dictionary LocalizableString {
 
 			<section>
 				<h3>Link relation type registration</h3>
-				<p class="note"> A request to register the <code>manifest</code> link relation type will be submitted to
+				<p class="note"> A request to register the <code>publication</code> link relation type will be submitted to
 					IANA. </p>
 				<dl>
 					<dt>Relation Name:</dt>


### PR DESCRIPTION
The text should say `publication` and not `manifest`


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/184.html" title="Last updated on Dec 19, 2019, 3:30 PM UTC (cc60a40)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/184/aa1f795...cc60a40.html" title="Last updated on Dec 19, 2019, 3:30 PM UTC (cc60a40)">Diff</a>