### PR TITLE
Changes to toc discovery

### DIFF
--- a/index.html
+++ b/index.html
@@ -2587,7 +2587,7 @@
 }</pre>
 					</section>
 
-					<section id="pub-table-of-contents">
+					<section id="contents">
 						<h5>Table of Contents</h5>
 
 						<p>The table of contents is a navigational aid that provides links to the major structural
@@ -2598,7 +2598,10 @@
 
 						<p>Only one resource MAY be identified as containing the table of contents. If multiple
 							instances are specified, user agents MUST use the first instance encountered, with
-							precedence given to the <a href="#default-reading-order">reading order</a>.</p>
+							precedence given to resources in the <a href="#default-reading-order">reading order</a>.</p>
+
+						<p><a>Profiles</a> of this specification MAY define how to locate a resource containing the
+							table of contents when no resource is identified by the <code>contents</code> relation.</p>
 
 						<p>The link to the table of contents MUST NOT be specified in the <a href="#links">links
 								list</a>.</p>
@@ -4741,7 +4744,8 @@ dictionary LocalizableString {
 					some steps, user agents are provided a choice in how to process the content to provide flexibility
 					for different presentation models.</p>
 
-				<p class="note">User agents can process and internalize the resulting structure in whatever language and form is appropriate.</p>
+				<p class="note">User agents can process and internalize the resulting structure in whatever language and
+					form is appropriate.</p>
 
 				<p>For the purposes of this algorithm, a <dfn>list element</dfn> is defined as either an
 						[[!html]]&#160;<a
@@ -4765,7 +4769,8 @@ dictionary LocalizableString {
 					</li>
 				</ol>
 
-				<p>The algorithm to locate the table of content element is executed on the structural resource defined in <a href="#pub-table-of-contents"></a>. A <a>profile</a> may also specify other possible resources.</p>
+				<p class="note">The rules for locating the resource containing the table of contents element are defined
+					in <a href="#contents"></a>.</p>
 
 				<p>If a table of contents element is not found, the publication does not have a table of contents that
 					can be used for machine rendering purposes.</p>
@@ -5563,7 +5568,7 @@ dictionary LocalizableString {
 							<code>contents</code>
 						</td>
 						<td>
-							<a href="#pub-table-of-contents"></a>
+							<a href="#contents"></a>
 						</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
A few minor tweaks:
- adds profile discovery option to toc relation section
- changes remaining algo text to a note


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/185.html" title="Last updated on Jan 7, 2020, 6:01 PM UTC (81526e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/185/7a93437...81526e3.html" title="Last updated on Jan 7, 2020, 6:01 PM UTC (81526e3)">Diff</a>