### PR TITLE
presentational aspects of toc lost with processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -4544,6 +4544,14 @@ dictionary LocalizableString {
 					links (excluding the <code>href</code> attribute), providing additional flexibility in how the table
 					of contents is constructed (e.g., to omit links to certain headings or only link to certain content
 					in a preview).</p>
+
+				<p>Note, however, that user agents are <strong>not required</strong> to preserve the presentational
+					aspects of the table of contents (i.e., the user agent is typically extracting the information in
+					order to present it in a common way across all publications). User agents are only expected to
+					retain the text content of the link elements, for example, so text styling, inline images and other
+					non-text content might be lost. Similarly, list styling and even how many levels deep of linking to
+					display are at the discretion of the user agent. For this reason, linking to the presentational
+					table of contents so that users are not limited to the machine-processed one is advised.</p>
 			</section>
 
 			<section id="app-toc-html">

--- a/index.html
+++ b/index.html
@@ -5633,5 +5633,5 @@ dictionary LocalizableString {
 			</table>
 		</section>
 		<section id="ack" data-include="common/html/acknowledgements.html" data-include-replace="true"></section>
-	</body>
+	</body> 
 </html>


### PR DESCRIPTION
This PR fixes #173 by adding a paragraph explaining that the processed table of contents does not have to retain the presentational aspects of the toc.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/190.html" title="Last updated on Jan 27, 2020, 8:11 PM UTC (0916c5b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/190/24ac983...0916c5b.html" title="Last updated on Jan 27, 2020, 8:11 PM UTC (0916c5b)">Diff</a>