### PR TITLE
Updated the pub.js script

### DIFF
--- a/common/js/pub.js
+++ b/common/js/pub.js
@@ -70,9 +70,13 @@ function create_manifest(config) {
     // =====================================================================
     let manifest = {
         "@context"             : ["https://schema.org", "https://www.w3.org/ns/pub-context"],
-        "type"                : "TechArticle",
+        "type"                 : "TechArticle",
         "accessMode"           : ["textual", "diagramOnVisual"],
-        "accessModeSufficient" : ["textual"],
+        "accessModeSufficient" : [{
+            "type"            : "ItemList",
+            "itemListElement" : ["textual"]
+        }],
+        "conformsTo"           : "https://www.w3.org/TR/pub-manifest/",
 
         "resources"            : [{
             "type"            : "LinkedResource",
@@ -85,6 +89,10 @@ function create_manifest(config) {
             "rel"             : "stylesheet",
             "encodingFormat"  : "text/css",
             "description"     : "Generic CSS file for W3C TR documents"                   	
+        },{
+            "type"            : "LinkedResource",
+            "url"             : "#",
+            "rel"             : "contents"
         }],
 
         "links"                : [{


### PR DESCRIPTION
This PR updates the js file that generated a publication manifest (as an embedded manifest) into the generated file, ie, the TR document. The manifest generated before was incorrect for the current spec.

However... we may want to discuss whether we should use this script in the first place. The issues are as follows:

There is only one standard "profile", ie, audiobooks. There is no such profile as a "single file publication", "technical document", or whatever, that would apply to a W3C document. In other words, the generated manifest:

- uses a non-standard `conformsTo` value (simply `https://www.w3.org/TR/pub-manifest`) which is a straightforward "basic" profile, but is not formally defined in our documents
- there is no fallback, in the general case, on the Primary Entry Point as for the location for the TOC (that is left to profiles, and is indeed specified for audiobooks), which means that an explicit `content` link reference is added to `resources` with the unorthodox value of a single `#` as the value of `href` to ensure that the TOC is found in the current file. It works, it is "legal", but it is a hack nevertheless (the spec says that fragments SHOULD NOT be used).

One possibility is to remove this script from the editor's version altogether. I am not sure what is the better way.

(This was originally done for Web Publications when it made more sense and fell under the adage "eat your own dog food"...)

---

(Note: whatever we decide, the change either removing the script or upgrading to the version in this PR must be done for audiobooks, too)