### PR TITLE
Correct PublicationManifest WebIDL

### DIFF
--- a/index.html
+++ b/index.html
@@ -4404,8 +4404,7 @@
 					<pre id="wpm">
 dictionary PublicationManifest {
              sequence&lt;DOMString>         type = "CreativeWork";
-    required DOMString                   profile;
-             sequence&lt;DOMString>         conformsTo;
+    required sequence&lt;DOMString>         conformsTo;
              DOMString                   id;
              boolean                     abridged;
              sequence&lt;DOMString>         accessMode;


### PR DESCRIPTION
Suppress a deprecated "profile" value, implemented as "conformsTo".

Typo spotted while checking the WebIDL dictionary of manifest properties.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 504 Gateway Time-out :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Apr 14, 2020, 8:03 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fpub-manifest%2Fb460c7b03fdf454d3510cffb39a9f5ceffdcb275%2Findex.html%3FisPreview%3Dtrue)

```
<html><body><h1>504 Gateway Time-out</h1>
The server didn't respond in time.
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/pub-manifest%23204.)._
</details>
