### PR TITLE
Fix accessmodesufficient's webidl definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -4408,7 +4408,7 @@ dictionary PublicationManifest {
              DOMString                   id;
              boolean                     abridged;
              sequence&lt;DOMString>         accessMode;
-             sequence&lt;DOMString>         accessModeSufficient;
+             sequence&lt;object>            accessModeSufficient;
              sequence&lt;DOMString>         accessibilityFeature;
              sequence&lt;DOMString>         accessibilityHazard;
              sequence&lt;LocalizableString> accessibilitySummary;


### PR DESCRIPTION
Fixes #206 by changing sequence<DOMString> to sequence<object>


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/209.html" title="Last updated on Apr 15, 2020, 3:47 PM UTC (c521560)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/209/3425460...c521560.html" title="Last updated on Apr 15, 2020, 3:47 PM UTC (c521560)">Diff</a>