### PR TITLE
Removing the third bullet in the definition of LocalizableString

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,9 +362,8 @@
 
 						<ul>
 							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
-								value;</li>
-							<li>a <a><code>LocalizableString</code></a>; or</li>
-							<li>an <a href="#value-array">Array</a> of <a><code>LocalizableStrings</code></a>.</li>
+								value; or</li>
+							<li>a <a><code>LocalizableString</code></a>; </li>
 						</ul>
 
 						<p>A single string value represents an implied object whose <code>value</code> property is the


### PR DESCRIPTION
(This was a spec bug...)

Fix #205


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/210.html" title="Last updated on Apr 15, 2020, 3:53 PM UTC (1f187f6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/210/b460c7b...1f187f6.html" title="Last updated on Apr 15, 2020, 3:53 PM UTC (1f187f6)">Diff</a>