### PR TITLE
change resource location text to match examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -361,8 +361,8 @@
 							as its value, the value MUST be expressed as one of:</p>
 
 						<ul>
-							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a>
-								value; or</li>
+							<li>a [[!json]] <a href="https://tools.ietf.org/html/rfc4627#section-2.5">string</a> value;
+								or</li>
 							<li>a <a><code>LocalizableString</code></a>.</li>
 						</ul>
 
@@ -2648,8 +2648,8 @@
 						<p class="ednote">The <code>accessibility-report</code> term is not currently registered in the
 							IANA link relations but the Working Group expects to add it.</p>
 
-						<p>It is RECOMMENDED that the report be included as a resource of the publication so that it is
-							available, for example, when a publication is read offline.</p>
+						<p>It is helpful to include the report as a resource of the publication so that it is available,
+							for example, when a publication is read offline.</p>
 
 						<p class="note">Providing the accessibility report in a human-readable format, such as HTML
 							[[html]], helps ensure that it can be accessed and understood by users. Augmenting the
@@ -2721,9 +2721,9 @@
 							if no information is collected, such a declaration increases the trust users have in the
 							content.</p>
 
-						<p>A link to a privacy policy can be included in the manifest for this purposes. It is
-							RECOMMENDED that the privacy policy be included as a resource of the publication so that it
-							is available, for example, when a publication is read offline.</p>
+						<p>A link to a privacy policy can be included in the manifest for this purposes. It is helpful
+							to include the privacy policy as a resource of the publication so that it is available, for
+							example, when a publication is read offline.</p>
 
 						<p>A <dfn data-lt="privacyPolicy">privacy policy</dfn> is identified using the
 								<code>privacy-policy</code> link relation&#160;[[!iana-link-relations]].</p>

--- a/index.html
+++ b/index.html
@@ -2658,7 +2658,8 @@
 
 						<pre class="example" title="Setting a link to an accessibility report.">{
     …
-    "links" : [
+    "resources" : [
+        …
         {
             "type" : "LinkedResource",
             "url"  : "https://www.publisher.example.org/sherlock-holmes-accessibility.html",
@@ -2730,7 +2731,8 @@
 
 						<pre class="example" title="Identifying a privacy policy via an external link.">{
     …
-    "links"  : [
+    "resources"  : [
+        …
         {
             "type"           : "LinkedResource",
             "url"            : "https://www.w3.org/Consortium/Legal/privacy-statement-20140324",

--- a/index.html
+++ b/index.html
@@ -5241,6 +5241,10 @@ dictionary LocalizableString {
 						>previous version</a></h3>
 
 				<ul>
+					<li>16-Apr-2020: Changed the recommendation that a privacy policy and accessibility report be
+						resources of a publication to best practice to match with the examples where these are listed as
+						links. Adding as links should not generate warnings. See <a
+							href="https://github.com/w3c/pub-manifest/issues/207">issue 207</a>.</li>
 					<li>15-Apr-2020: Removed the bullet from the LocalizableString definition allowing an array of
 						values, as this creates an invalid nesting of arrays when paired with the value categories. See
 							<a href="https://github.com/w3c/pub-manifest/issues/205">issue 205</a>.</li>


### PR DESCRIPTION
Fixes #207 by changing the recommendation for a privacy policy and accessibility report to be resources of the publication (i.e., warnings if not) to best practices. This matches their inclusion in the links section in the examples.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/212.html" title="Last updated on Apr 16, 2020, 4:25 PM UTC (a1b2ecd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/212/48dbca5...a1b2ecd.html" title="Last updated on Apr 16, 2020, 4:25 PM UTC (a1b2ecd)">Diff</a>