### PR TITLE
explain author/creator equivalence problem

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,55 +10,49 @@
 		<link href="https://unpkg.com/reqlist/lib/reqlist.css" class="removeOnSave" rel="stylesheet" type="text/css" />
 		<link href="common/css/common.css" rel="stylesheet" type="text/css" />
 		<script class="remove">
-			// <![CDATA[
+			//<![CDATA[
 			var respecConfig = {
-				preProcess: [
-					prepare_reqlist
-				],
-				postProcess: [
-					convert_dfn_to_link,
-					add_reqlist_button
-				],
+				preProcess:[
+				prepare_reqlist],
+				postProcess:[
+				convert_dfn_to_link,
+				add_reqlist_button],
 				wg: "Publishing Working Group",
 				specStatus: "ED",
 				shortName: "pub-manifest",
 				previousPublishDate: "2020-03-17",
 				previousMaturity: "CR",
 				implementationReportURI: "https://www.w3.org/publishing/groups/publ-wg/implementation/results.html",
-				crEnd : "2020-03-31",
+				crEnd: "2020-03-31",
 				edDraftURI: "https://w3c.github.io/pub-manifest/",
-				editors: [
-					{
-						"name": "Matt Garrish",
-						"company": "DAISY Consortium",
-						"companyURL": "https://daisy.org",
-						"w3cid": 51655
-					},
-					{
-						"name": "Ivan Herman",
-						"url": "https://www.w3.org/People/Ivan/",
-						"company": "W3C",
-						"w3cid": 7382,
-						"orcid": "0000-0003-0782-2704",
-						"companyURL": "https://www.w3.org",
-					}
-				],
+				editors:[ {
+					"name": "Matt Garrish",
+					"company": "DAISY Consortium",
+					"companyURL": "https://daisy.org",
+					"w3cid": 51655
+				}, {
+					"name": "Ivan Herman",
+					"url": "https://www.w3.org/People/Ivan/",
+					"company": "W3C",
+					"w3cid": 7382,
+					"orcid": "0000-0003-0782-2704",
+					"companyURL": "https://www.w3.org",
+				}],
 				processVersion: 2018,
 				includePermalinks: false,
-				permalinkEdge:     true,
-				permalinkHide:     false,
-				pluralize:         true,
-				diffTool:          "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
-				wgURI:             "https://www.w3.org/publishing/groups/publ-wg/",
-				wgPublicList:      "public-publ-wg",
-				wgPatentURI:       "https://www.w3.org/2004/01/pp-impl/100074/status",
-				github:			 {
+				permalinkEdge: true,
+				permalinkHide: false,
+				pluralize: true,
+				diffTool: "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+				wgURI: "https://www.w3.org/publishing/groups/publ-wg/",
+				wgPublicList: "public-publ-wg",
+				wgPatentURI: "https://www.w3.org/2004/01/pp-impl/100074/status",
+				github: {
 					repoURL: "https://github.com/w3c/pub-manifest/",
 					branch: "master"
 				},
 				localBiblio: localBiblio
-			};
-			// ]]>
+			};//]]>
 	  </script>
 		<style>
 			var {
@@ -1569,11 +1563,11 @@
 									</td>
 									<td>
 										<p>The creator of the publication.</p>
-										<p>Use of this property might lead to inconsistent results in user agents. It
-											is marked as a synonym for <a href="#author">author</a> in [[schema.org]],
-											but there is no guidance on which takes precedence or how to combine them.
-											It is advised to use only one or the other, with preference given to the
-											more specific author property.</p>
+										<p>Use of this property might lead to inconsistent results in user agents. It is
+											marked as a synonym for <a href="#author">author</a> in [[schema.org]], but
+											there is no guidance on which takes precedence or how to combine them. It is
+											advised to use only one or the other, with preference given to the more
+											specific author property.</p>
 									</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
 											<a href="https://schema.org/Organization"
@@ -5244,6 +5238,9 @@ dictionary LocalizableString {
 						>previous version</a></h3>
 
 				<ul>
+					<li>30-Apr-2020: Noted the issue with the author and creator properties being synonyms in
+						schema.org. See <a href="https://github.com/w3c/pub-manifest/issues/203#issuecomment-614004609"
+							>issue 203</a>.</li>
 					<li>16-Apr-2020: Changed the recommendation that a privacy policy and accessibility report be
 						resources of a publication to best practice to match with the examples where these are listed as
 						links. Adding as links should not generate warnings. See <a

--- a/index.html
+++ b/index.html
@@ -1572,7 +1572,7 @@
 										<p>Use of this property might lead to inconsistent results in user agents. It
 											is marked as a synonym for <a href="#author">author</a> in [[schema.org]],
 											but there is no guidance on which takes precedence or how to combine them.
-											It is advised to only use one or the other, with preference given to the
+											It is advised to use only one or the other, with preference given to the
 											more specific author property.</p>
 									</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or

--- a/index.html
+++ b/index.html
@@ -10,49 +10,55 @@
 		<link href="https://unpkg.com/reqlist/lib/reqlist.css" class="removeOnSave" rel="stylesheet" type="text/css" />
 		<link href="common/css/common.css" rel="stylesheet" type="text/css" />
 		<script class="remove">
-			//<![CDATA[
+			// <![CDATA[
 			var respecConfig = {
-				preProcess:[
-				prepare_reqlist],
-				postProcess:[
-				convert_dfn_to_link,
-				add_reqlist_button],
+				preProcess: [
+					prepare_reqlist
+				],
+				postProcess: [
+					convert_dfn_to_link,
+					add_reqlist_button
+				],
 				wg: "Publishing Working Group",
 				specStatus: "ED",
 				shortName: "pub-manifest",
 				previousPublishDate: "2020-03-17",
 				previousMaturity: "CR",
 				implementationReportURI: "https://www.w3.org/publishing/groups/publ-wg/implementation/results.html",
-				crEnd: "2020-03-31",
+				crEnd : "2020-03-31",
 				edDraftURI: "https://w3c.github.io/pub-manifest/",
-				editors:[ {
-					"name": "Matt Garrish",
-					"company": "DAISY Consortium",
-					"companyURL": "https://daisy.org",
-					"w3cid": 51655
-				}, {
-					"name": "Ivan Herman",
-					"url": "https://www.w3.org/People/Ivan/",
-					"company": "W3C",
-					"w3cid": 7382,
-					"orcid": "0000-0003-0782-2704",
-					"companyURL": "https://www.w3.org",
-				}],
+				editors: [
+					{
+						"name": "Matt Garrish",
+						"company": "DAISY Consortium",
+						"companyURL": "https://daisy.org",
+						"w3cid": 51655
+					},
+					{
+						"name": "Ivan Herman",
+						"url": "https://www.w3.org/People/Ivan/",
+						"company": "W3C",
+						"w3cid": 7382,
+						"orcid": "0000-0003-0782-2704",
+						"companyURL": "https://www.w3.org",
+					}
+				],
 				processVersion: 2018,
 				includePermalinks: false,
-				permalinkEdge: true,
-				permalinkHide: false,
-				pluralize: true,
-				diffTool: "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
-				wgURI: "https://www.w3.org/publishing/groups/publ-wg/",
-				wgPublicList: "public-publ-wg",
-				wgPatentURI: "https://www.w3.org/2004/01/pp-impl/100074/status",
-				github: {
+				permalinkEdge:     true,
+				permalinkHide:     false,
+				pluralize:         true,
+				diffTool:          "http://www.aptest.com/standards/htmldiff/htmldiff.pl",
+				wgURI:             "https://www.w3.org/publishing/groups/publ-wg/",
+				wgPublicList:      "public-publ-wg",
+				wgPatentURI:       "https://www.w3.org/2004/01/pp-impl/100074/status",
+				github:			 {
 					repoURL: "https://github.com/w3c/pub-manifest/",
 					branch: "master"
 				},
 				localBiblio: localBiblio
-			};//]]>
+			};
+			// ]]>
 	  </script>
 		<style>
 			var {

--- a/index.html
+++ b/index.html
@@ -1567,7 +1567,14 @@
 									<td id="creator">
 										<code>creator</code>
 									</td>
-									<td>The creator of the publication.</td>
+									<td>
+										<p>The creator of the publication.</p>
+										<p>Use of this property might lead to inconsistent results in user agents, as it
+											is marked as a synonym for <a href="#author">author</a> in [[schema.org]]
+											but there is no guidance on which takes precedence or how to combine them.
+											It is advised to only use one or the other, with preference given to the
+											more specific author property.</p>
+									</td>
 									<td>One or more <a href="https://schema.org/Person"><code>Person</code></a> and/or
 											<a href="https://schema.org/Organization"
 										><code>Organization</code></a>.</td>

--- a/index.html
+++ b/index.html
@@ -1569,8 +1569,8 @@
 									</td>
 									<td>
 										<p>The creator of the publication.</p>
-										<p>Use of this property might lead to inconsistent results in user agents, as it
-											is marked as a synonym for <a href="#author">author</a> in [[schema.org]]
+										<p>Use of this property might lead to inconsistent results in user agents. It
+											is marked as a synonym for <a href="#author">author</a> in [[schema.org]],
 											but there is no guidance on which takes precedence or how to combine them.
 											It is advised to only use one or the other, with preference given to the
 											more specific author property.</p>


### PR DESCRIPTION
Here's a weak-kneed attempt to dodge the problem of author-creator equivalency in schema.org. It blames schema.org for the problem, prefers author and generally avoids saying anything normative.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/214.html" title="Last updated on Apr 30, 2020, 9:46 AM UTC (ea0a248)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/214/34cc0a4...ea0a248.html" title="Last updated on Apr 30, 2020, 9:46 AM UTC (ea0a248)">Diff</a>