### PR TITLE
clarify where duplicate resources are checked

### DIFF
--- a/index.html
+++ b/index.html
@@ -3694,7 +3694,7 @@
 									which represents the complete list of unique resources within the <a
 										href="#publication-resources">bounds of the publication</a>.</p>
 								<p>This step also warns if either the <var>readingOrder</var> or <var>resources</var>
-									contains dupliate resources declarations. The validation errors are emitted as part
+									contains dupliate resource declarations. The validation errors are emitted as part
 									of obtaining the unique URLs from each list.</p>
 							</details>
 						</li>

--- a/index.html
+++ b/index.html
@@ -3693,6 +3693,9 @@
 									list. It then sets <var>data['uniqueResources']</var> the union of these two sets,
 									which represents the complete list of unique resources within the <a
 										href="#publication-resources">bounds of the publication</a>.</p>
+								<p>This step also warns if either the <var>readingOrder</var> or <var>resources</var>
+									contains dupliate resources declarations. The validation errors are emitted as part
+									of obtaining the unique URLs from each list.</p>
 							</details>
 						</li>
 


### PR DESCRIPTION
Step 11 of the data validation algorithm isn't very clear that it is also where the readingOrder and resource lists are checked for duplicate declarations. This PR just adds a bit of explanation to this effect.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/217.html" title="Last updated on Apr 30, 2020, 5:27 PM UTC (58e22e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/217/c114a5c...58e22e1.html" title="Last updated on Apr 30, 2020, 5:27 PM UTC (58e22e1)">Diff</a>