### PR TITLE
fix schema expected data types

### DIFF
--- a/schema/ItemList.schema.json
+++ b/schema/ItemList.schema.json
@@ -1,0 +1,38 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "ItemList.schema.json",
+    "title": "schema.org ItemList object",
+    "type": "object",
+    "properties": {
+        "type": {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "const": "ItemList"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "contains": {
+                        "const": "ItemList"
+                    }
+                }
+            ]
+        },
+        "itemListElement": {
+            "type": [
+            	"array"
+            ],
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        }
+    },
+    "required": [
+        "type",
+        "itemListElement" 
+    ]
+}

--- a/schema/ItemList.schema.json
+++ b/schema/ItemList.schema.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "type": {
-            "anyOf": [
+            "oneOf": [
                 {
                     "type": "string",
                     "const": "ItemList"

--- a/schema/contributor-object.schema.json
+++ b/schema/contributor-object.schema.json
@@ -11,7 +11,7 @@
             "$ref": "url.schema.json"
         },
         "type": {
-            "anyOf": [
+            "oneOf": [
                 {
                     "type": "string",
                     "enum": [

--- a/schema/link.schema.json
+++ b/schema/link.schema.json
@@ -5,7 +5,7 @@
     "type": "object",
     "properties": {
         "type": {
-            "anyOf": [
+            "oneOf": [
                 {
                     "type": "string",
                     "const": "LinkedResource"

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -1,183 +1,194 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "publication.schema.json",
-    "title": "Publication Manifest",
-    "type": "object",
-    "properties": {
-        "@context": {
-            "type": "array",
-            "items": [
-                {
-                    "const": "https://schema.org"
-                },
-                {
-                    "const": "https://www.w3.org/ns/pub-context"
-                }
-            ],
-            "additionalItems": true,
-            "uniqueItems": true
-        },
-        "type": {
-            "type": [
-                "string",
-                "array"
-            ],
-            "items": {
-                "type": "string"
-            },
-            "uniqueItems": true
-        },
-        "conformsTo" : {
-            "oneOf": [
-                {
-                    "$ref": "url.schema.json"
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "$ref": "url.schema.json"
-                    }        
-                }
-            ]
-        },
-        "id": {
-            "type": "string"
-        },
-        "abridged": {
-        	"type": "boolean"
-        },
-        "accessMode": {
-            "type": [
-                "string",
-                "array"
-            ],
-            "items": {
-                "type": "string"
-            },
-            "uniqueItems": true
-        },
-        "accessModeSufficient": {
-        	"$ref": "ItemList.schema.json"
-        },
-        "accessibilityFeature": {
-            "type": [
-                "string",
-                "array"
-            ],
-            "items": {
-                "type": "string"
-            },
-            "uniqueItems": true
-        },
-        "accessibilityHazard": {
-            "type": [
-            	"string",
-            	"array"
-            ],
-            "items": {
-                "type": "string"
-            },
-            "uniqueItems": true
-        },
-        "accessibilitySummary": {
-            "$ref": "localizable.schema.json"
-        },
-        "artist": {
-            "$ref": "contributor.schema.json"
-        },
-        "author": {
-            "$ref": "contributor.schema.json"
-        },
-        "colorist": {
-            "$ref": "contributor.schema.json"
-        },
-        "contributor": {
-            "$ref": "contributor.schema.json"
-        },
-        "creator": {
-            "$ref": "contributor.schema.json"
-        },
-        "editor": {
-            "$ref": "contributor.schema.json"
-        },
-        "illustrator": {
-            "$ref": "contributor.schema.json"
-        },
-        "inker": {
-            "$ref": "contributor.schema.json"
-        },
-        "letterer": {
-            "$ref": "contributor.schema.json"
-        },
-        "penciler": {
-            "$ref": "contributor.schema.json"
-        },
-        "publisher": {
-            "$ref": "contributor.schema.json"
-        },
-        "readBy": {
-            "$ref": "contributor.schema.json"
-        },
-        "translator": {
-            "$ref": "contributor.schema.json"
-        },
-        "url": {
-            "$ref": "url.schema.json"
-        },
-        "duration": {
-            "type": "string",
-            "pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"
-        },
-        "inLanguage": {
-            "oneOf": [
-                {
-                    "$ref": "bcp.schema.json"
-                },
-                {
-                    "type": "array",
-                    "items": {
-                        "$ref": "bcp.schema.json"
-                    }        
-                }
-            ]
-        },
-        "dateModified": {
-            "type": "string",
-            "anyOf": [
-                {
-                    "format": "date"
-                },
-                {
-                    "format": "date-time"
-                }
-            ]
-        },
-        "datePublished": {
-            "type": "string",
-            "anyOf": [
-                {
-                    "format": "date"
-                },
-                {
-                    "format": "date-time"
-                }
-            ]
-        },
-        "name": {
-            "$ref": "localizable.schema.json"
-        },
-        "readingOrder": {
-            "$ref": "resource.categorization.schema.json"
-        },
-        "resources": {
-            "$ref": "resource.categorization.schema.json"
-        },
-        "links": {
-            "$ref": "resource.categorization.schema.json"
-        }
-    },
-    "required": [
-        "@context",
-        "conformsTo"
-    ]
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "publication.schema.json",
+	"title": "Publication Manifest",
+	"type": "object",
+	"properties": {
+		"@context": {
+			"type": "array",
+			"items": [
+				{
+					"const": "https://schema.org"
+				},
+				{
+					"const": "https://www.w3.org/ns/pub-context"
+				}
+			],
+			"additionalItems": true,
+			"uniqueItems": true
+		},
+		"type": {
+			"type": [
+				"string",
+				"array"
+			],
+			"items": {
+				"type": "string"
+			},
+			"uniqueItems": true
+		},
+		"conformsTo" : {
+			"oneOf": [
+				{
+					"$ref": "url.schema.json"
+				},
+				{
+					"type": "array",
+					"items": {
+						"$ref": "url.schema.json"
+					}		
+				}
+			]
+		},
+		"id": {
+			"type": "string"
+		},
+		"abridged": {
+			"type": "boolean"
+		},
+		"accessMode": {
+			"type": [
+				"string",
+				"array"
+			],
+			"items": {
+				"type": "string"
+			},
+			"uniqueItems": true
+		},
+		"accessModeSufficient": {
+			"oneOf": [
+				{
+					"$ref": "ItemList.schema.json"
+				},
+				{
+					"type": "array",
+					"items": {
+						"$ref": "ItemList.schema.json"
+					},
+					"uniqueItems": true
+				}
+			]
+		},
+		"accessibilityFeature": {
+			"type": [
+				"string",
+				"array"
+			],
+			"items": {
+				"type": "string"
+			},
+			"uniqueItems": true
+		},
+		"accessibilityHazard": {
+			"type": [
+				"string",
+				"array"
+			],
+			"items": {
+				"type": "string"
+			},
+			"uniqueItems": true
+		},
+		"accessibilitySummary": {
+			"$ref": "localizable.schema.json"
+		},
+		"artist": {
+			"$ref": "contributor.schema.json"
+		},
+		"author": {
+			"$ref": "contributor.schema.json"
+		},
+		"colorist": {
+			"$ref": "contributor.schema.json"
+		},
+		"contributor": {
+			"$ref": "contributor.schema.json"
+		},
+		"creator": {
+			"$ref": "contributor.schema.json"
+		},
+		"editor": {
+			"$ref": "contributor.schema.json"
+		},
+		"illustrator": {
+			"$ref": "contributor.schema.json"
+		},
+		"inker": {
+			"$ref": "contributor.schema.json"
+		},
+		"letterer": {
+			"$ref": "contributor.schema.json"
+		},
+		"penciler": {
+			"$ref": "contributor.schema.json"
+		},
+		"publisher": {
+			"$ref": "contributor.schema.json"
+		},
+		"readBy": {
+			"$ref": "contributor.schema.json"
+		},
+		"translator": {
+			"$ref": "contributor.schema.json"
+		},
+		"url": {
+			"$ref": "url.schema.json"
+		},
+		"duration": {
+			"type": "string",
+			"pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"
+		},
+		"inLanguage": {
+			"oneOf": [
+				{
+					"$ref": "bcp.schema.json"
+				},
+				{
+					"type": "array",
+					"items": {
+						"$ref": "bcp.schema.json"
+					}		
+				}
+			]
+		},
+		"dateModified": {
+			"type": "string",
+			"anyOf": [
+				{
+					"format": "date"
+				},
+				{
+					"format": "date-time"
+				}
+			]
+		},
+		"datePublished": {
+			"type": "string",
+			"anyOf": [
+				{
+					"format": "date"
+				},
+				{
+					"format": "date-time"
+				}
+			]
+		},
+		"name": {
+			"$ref": "localizable.schema.json"
+		},
+		"readingOrder": {
+			"$ref": "resource.categorization.schema.json"
+		},
+		"resources": {
+			"$ref": "resource.categorization.schema.json"
+		},
+		"links": {
+			"$ref": "resource.categorization.schema.json"
+		}
+	},
+	"required": [
+		"@context",
+		"conformsTo"
+	]
 }

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -57,14 +57,7 @@
             "uniqueItems": true
         },
         "accessModeSufficient": {
-            "type": [
-                "string",
-                "array"
-            ],
-            "items": {
-                "type": "string"
-            },
-            "uniqueItems": true
+        	"$ref": "ItemList.schema.json"
         },
         "accessibilityFeature": {
             "type": [
@@ -77,7 +70,10 @@
             "uniqueItems": true
         },
         "accessibilityHazard": {
-            "type": "array",
+            "type": [
+            	"string",
+            	"array"
+            ],
             "items": {
                 "type": "string"
             },


### PR DESCRIPTION
Fixes #218 and fixes #219.

- Allows a single string value for `accessibilityHazard`
- Requires one or more ItemList objects for `accessModeSufficient`