### PR TITLE
Schema data type fixes

### DIFF
--- a/schema/context.schema.json
+++ b/schema/context.schema.json
@@ -21,7 +21,8 @@
 				"properties": {
 					"language": {
 						"$ref": "bcp.schema.json"
-					}
+					},
+					"direction": false
 				},
 				"required": ["language"]
 			},
@@ -31,9 +32,23 @@
 					"direction": {
 						"type": "string",
 						"enum": ["ltr", "rtl"]
-					}
+					},
+					"language": false
 				},
 				"required": ["direction"]
+			},
+			{
+				"type": "object",
+				"properties": {
+					"language": {
+						"$ref": "bcp.schema.json"
+					},
+					"direction": {
+						"type": "string",
+						"enum": ["ltr", "rtl"]
+					}
+				},
+				"required": ["language", "direction"]
 			},
 			{
 				"type": "object",

--- a/schema/context.schema.json
+++ b/schema/context.schema.json
@@ -1,0 +1,48 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "context.schema.json",
+	"title": "Publication Contexts",
+	"type": "array",
+	"items": [
+		{
+			"const": "https://schema.org"
+		},
+		{
+			"const": "https://www.w3.org/ns/pub-context"
+		}
+	],
+	"additionalItems": {
+		"anyOf": [
+			{
+				"type": "string"
+			},
+			{
+				"type": "object",
+				"properties": {
+					"language": {
+						"$ref": "bcp.schema.json"
+					}
+				},
+				"required": ["language"]
+			},
+			{
+				"type": "object",
+				"properties": {
+					"direction": {
+						"type": "string",
+						"enum": ["ltr", "rtl"]
+					}
+				},
+				"required": ["direction"]
+			},
+			{
+				"type": "object",
+				"properties": {
+					"language": false,
+					"direction": false
+				}
+			}
+		]
+	},
+	"uniqueItems": true
+}

--- a/schema/date.schema.json
+++ b/schema/date.schema.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "date.schema.json",
+	"title": "Dates",
+	"type": "string",
+	"anyOf": [
+		{
+			"format": "date"
+		},
+		{
+			"format": "date-time"
+		}
+	]
+}

--- a/schema/duration.schema.json
+++ b/schema/duration.schema.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "duration.schema.json",
+	"title": "Duration",
+	"type": "string",
+	"pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"
+}

--- a/schema/item-lists.schema.json
+++ b/schema/item-lists.schema.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "item-lists.schema.json",
+	"title": "Lists of ItemList",
+	"oneOf": [
+		{
+			"$ref": "ItemList.schema.json"
+		},
+		{
+			"type": "array",
+			"items": {
+				"$ref": "ItemList.schema.json"
+			},
+			"uniqueItems": true
+		}
+	]
+}

--- a/schema/language.schema.json
+++ b/schema/language.schema.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "language.schema.json",
+	"title": "Languages",
+	"oneOf": [
+		{
+			"$ref": "bcp.schema.json"
+		},
+		{
+			"type": "array",
+			"items": {
+				"$ref": "bcp.schema.json"
+			}		
+		}
+	]
+}

--- a/schema/link.schema.json
+++ b/schema/link.schema.json
@@ -57,18 +57,7 @@
             "pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"
         },
         "alternate": {
-            "type": "array",
-            "items": {
-                "anyOf": [
-                    {
-                        "$ref": "url.schema.json"
-                    },
-                    {
-                        "$ref": "link.schema.json"
-                    }
-                ]
-            },
-            "uniqueItems": true
+        	"$ref": "resource.categorization.schema.json"
         }
     },
     "required": [

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -5,17 +5,7 @@
 	"type": "object",
 	"properties": {
 		"@context": {
-			"type": "array",
-			"items": [
-				{
-					"const": "https://schema.org"
-				},
-				{
-					"const": "https://www.w3.org/ns/pub-context"
-				}
-			],
-			"additionalItems": true,
-			"uniqueItems": true
+			"$ref": "context.schema.json"
 		},
 		"type": {
 			"type": [
@@ -47,48 +37,16 @@
 			"type": "boolean"
 		},
 		"accessMode": {
-			"type": [
-				"string",
-				"array"
-			],
-			"items": {
-				"type": "string"
-			},
-			"uniqueItems": true
+			"$ref": "strings.schema.json"
 		},
 		"accessModeSufficient": {
-			"oneOf": [
-				{
-					"$ref": "ItemList.schema.json"
-				},
-				{
-					"type": "array",
-					"items": {
-						"$ref": "ItemList.schema.json"
-					},
-					"uniqueItems": true
-				}
-			]
+			"$ref": "item-lists.schema.json"
 		},
 		"accessibilityFeature": {
-			"type": [
-				"string",
-				"array"
-			],
-			"items": {
-				"type": "string"
-			},
-			"uniqueItems": true
+			"$ref": "strings.schema.json"
 		},
 		"accessibilityHazard": {
-			"type": [
-				"string",
-				"array"
-			],
-			"items": {
-				"type": "string"
-			},
-			"uniqueItems": true
+			"$ref": "strings.schema.json"
 		},
 		"accessibilitySummary": {
 			"$ref": "localizable.schema.json"
@@ -133,46 +91,19 @@
 			"$ref": "contributor.schema.json"
 		},
 		"url": {
-			"$ref": "url.schema.json"
+			"$ref": "urls.schema.json"
 		},
 		"duration": {
-			"type": "string",
-			"pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"
+			"$ref": "duration.schema.json"
 		},
 		"inLanguage": {
-			"oneOf": [
-				{
-					"$ref": "bcp.schema.json"
-				},
-				{
-					"type": "array",
-					"items": {
-						"$ref": "bcp.schema.json"
-					}		
-				}
-			]
+			"$ref": "language.schema.json"
 		},
 		"dateModified": {
-			"type": "string",
-			"anyOf": [
-				{
-					"format": "date"
-				},
-				{
-					"format": "date-time"
-				}
-			]
+			"$ref": "date.schema.json"
 		},
 		"datePublished": {
-			"type": "string",
-			"anyOf": [
-				{
-					"format": "date"
-				},
-				{
-					"format": "date-time"
-				}
-			]
+			"$ref": "date.schema.json"
 		},
 		"name": {
 			"$ref": "localizable.schema.json"

--- a/schema/strings.schema.json
+++ b/schema/strings.schema.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "strings.schema.json",
+	"title": "Unique strings",
+	"type": [
+		"string",
+		"array"
+	],
+	"items": {
+		"type": "string"
+	},
+	"uniqueItems": true
+}

--- a/schema/urls.schema.json
+++ b/schema/urls.schema.json
@@ -1,0 +1,19 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "urls.schema.json",
+	"title": "URLs",
+	"oneOf": [
+		{
+			"type": "string",
+			"format": "uri-reference"
+		},
+		{
+			"type": "array",
+			"items": {
+				"type": "string",
+				"format": "uri-reference"
+			},
+			"uniqueItems": true
+		}
+	]
+}


### PR DESCRIPTION
Fixes the following:

- adds validation for language and direction in the manifest @context
- allows more than one url for address
- fixes alternate so that mixes of strings and linkedresource objects are allowed in the array, as well as allow a single string or linkedresource object as the value;
- also atomizes some tests to reduce future maintenance in other schemas

Fixes #221, fixes #222, and fixes #223 
