### PR TITLE
Schemas fixes

### DIFF
--- a/schema/module/ItemList.schema.json
+++ b/schema/module/ItemList.schema.json
@@ -27,8 +27,7 @@
             ],
             "items": {
                 "type": "string"
-            },
-            "uniqueItems": true
+            }
         }
     },
     "required": [

--- a/schema/module/context.schema.json
+++ b/schema/module/context.schema.json
@@ -58,6 +58,5 @@
 				}
 			}
 		]
-	},
-	"uniqueItems": true
+	}
 }

--- a/schema/module/contributor.schema.json
+++ b/schema/module/contributor.schema.json
@@ -17,8 +17,7 @@
                         "$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor-object.schema.json"
                     }
                 ]
-            },
-            "uniqueItems": true
+            }
         },
         {
             "$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor-object.schema.json"

--- a/schema/module/item-lists.schema.json
+++ b/schema/module/item-lists.schema.json
@@ -10,8 +10,7 @@
 			"type": "array",
 			"items": {
 				"$ref": "https://w3c.github.io/pub-manifest/schema/module/ItemList.schema.json"
-			},
-			"uniqueItems": true
+			}
 		}
 	]
 }

--- a/schema/module/link.schema.json
+++ b/schema/module/link.schema.json
@@ -53,8 +53,7 @@
             "type": "string"
         },
         "duration": {
-            "type": "string",
-            "pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"
+        	"$ref": "https://w3c.github.io/pub-manifest/schema/module/duration.schema.json"
         },
         "alternate": {
         	"$ref": "https://w3c.github.io/pub-manifest/schema/module/resource.categorization.schema.json"

--- a/schema/module/localizable-object.schema.json
+++ b/schema/module/localizable-object.schema.json
@@ -8,8 +8,7 @@
             "type": "string"
         },
         "language": {
-            "type": "string",
-            "pattern": "^((?:(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?:([A-Za-z]{2,3}(-(?:[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-(?:[A-Za-z]{4}))?(-(?:[A-Za-z]{2}|[0-9]{3}))?(-(?:[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-(?:[0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(?:x(-[A-Za-z0-9]{1,8})+))?)|(?:x(-[A-Za-z0-9]{1,8})+))$"
+            "$ref": "https://w3c.github.io/pub-manifest/schema/module/bcp.schema.json"
         }
     },
     "required": [

--- a/schema/module/localizable.schema.json
+++ b/schema/module/localizable.schema.json
@@ -17,8 +17,7 @@
                         "$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable-object.schema.json"
                     }
                 ]
-            },
-            "uniqueItems": true
+            }
         },
         {
             "$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable-object.schema.json"

--- a/schema/module/strings.schema.json
+++ b/schema/module/strings.schema.json
@@ -8,6 +8,5 @@
 	],
 	"items": {
 		"type": "string"
-	},
-	"uniqueItems": true
+	}
 }

--- a/schema/module/urls.schema.json
+++ b/schema/module/urls.schema.json
@@ -12,8 +12,7 @@
 			"items": {
 				"type": "string",
 				"format": "uri-reference"
-			},
-			"uniqueItems": true
+			}
 		}
 	]
 }

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -14,8 +14,7 @@
 			],
 			"items": {
 				"type": "string"
-			},
-			"uniqueItems": true
+			}
 		},
 		"conformsTo" : {
 			"oneOf": [


### PR DESCRIPTION
A couple of additional things I've fixed in the schemas;

- We were using `uniqueItems: true` inconsistently and in many places where the specification says nothing about the need for uniqueness (even if it makes intuitive sense). You can declare a `type` more than once, for example, without negative effect. I'd suggest we leave messages about duplication for a full-fledged validator to handle, as these shouldn't be errors but more along the lines of epubcheck's info messages (best practices). The only required uniqueness is within `resources`, `readingOrder` and `links` and that check remains in the resource.categorization.schema.json file.
- I replaced two additional regexes for duration/language checking with a references to the patterns I broke out earlier.