### PR TITLE
Update schema urls to use w3c address

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,8 +171,8 @@
 
 				<p class="note">This shape is also defined, informally, through a JSON schema&#160;[[json-schema]] that
 					expresses the constraints defined in this specification. This schema is maintained at <a
-						href="https://www.w3.org/ns/pub-manifest/schema/"
-					>https://www.w3.org/ns/pub-manifest/schema/</a>.</p>
+						href="https://www.w3.org/ns/pub-schema/manifest/"
+					>https://www.w3.org/ns/pub-schema/manifest/</a>.</p>
 
 				<p>The publication manifest also has a number of authoring flexibilities and compact authoring
 					expressions. For example, it is not always required that object types be explicitly authored, as

--- a/index.html
+++ b/index.html
@@ -171,8 +171,8 @@
 
 				<p class="note">This shape is also defined, informally, through a JSON schema&#160;[[json-schema]] that
 					expresses the constraints defined in this specification. This schema is maintained at <a
-						href="https://github.com/w3c/pub-manifest/blob/master/schema/"
-						>https://github.com/w3c/pub-manifest/blob/master/schema/</a>.</p>
+						href="https://www.w3.org/ns/pub-manifest/schema/"
+					>https://www.w3.org/ns/pub-manifest/schema/</a>.</p>
 
 				<p>The publication manifest also has a number of authoring flexibilities and compact authoring
 					expressions. For example, it is not always required that object types be explicitly authored, as
@@ -5248,6 +5248,8 @@ dictionary LocalizableString {
 						>previous version</a></h3>
 
 				<ul>
+					<li>27-July-2020: Updated the reference schema URL to a W3C address. See <a
+							href="https://github.com/w3c/pub-manifest/issues/226">issue 226</a>.</li>
 					<li>30-Apr-2020: Noted the issue with the author and creator properties being synonyms in
 						schema.org. See <a href="https://github.com/w3c/pub-manifest/issues/203#issuecomment-614004609"
 							>issue 203</a>.</li>

--- a/schema/README.md
+++ b/schema/README.md
@@ -10,7 +10,7 @@ The schema is updated to newer drafts as broad support in validators becomes ava
 
 The schema consists of a primary schema file `publication.schema.json` and several component files, each of which encapsulates tests specific to an area of validation. These component files are located in the `module` subdirectory.
 
-In some cases, it may be possible to validate without downloading the physical schemas (i.e., if the validator can retrieve the schemas automatically). In these cases, only the URL `https://w3c.github.io/pub-manifest/schema/publication.schema.json` needs to be specified.
+In some cases, it may be possible to validate without downloading the physical schemas (i.e., if the validator can retrieve the schemas automatically). In these cases, only the URL `https://www.w3.org/ns/pub-manifest/schema/publication.schema.json` needs to be specified.
 
 ## Validators
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -10,7 +10,7 @@ The schema is updated to newer drafts as broad support in validators becomes ava
 
 The schema consists of a primary schema file `publication.schema.json` and several component files, each of which encapsulates tests specific to an area of validation. These component files are located in the `module` subdirectory.
 
-In some cases, it may be possible to validate without downloading the physical schemas (i.e., if the validator can retrieve the schemas automatically). In these cases, only the URL `https://www.w3.org/ns/pub-manifest/schema/publication.schema.json` needs to be specified.
+In some cases, it may be possible to validate without downloading the physical schemas (i.e., if the validator can retrieve the schemas automatically). In these cases, only the URL `https://www.w3.org/ns/pub-schema/manifest/publication.schema.json` needs to be specified.
 
 ## Validators
 

--- a/schema/module/ItemList.schema.json
+++ b/schema/module/ItemList.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/ItemList.schema.json",
+    "$id": "https://www.w3.org/ns/pub-schema/manifest/module/ItemList.schema.json",
     "title": "schema.org ItemList object",
     "type": "object",
     "properties": {

--- a/schema/module/ItemList.schema.json
+++ b/schema/module/ItemList.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://w3c.github.io/pub-manifest/schema/module/ItemList.schema.json",
+    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/ItemList.schema.json",
     "title": "schema.org ItemList object",
     "type": "object",
     "properties": {

--- a/schema/module/bcp.schema.json
+++ b/schema/module/bcp.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/bcp.schema.json",
+    "$id": "https://www.w3.org/ns/pub-schema/manifest/module/bcp.schema.json",
     "title": "BCP47 Language tag",
     "type": "string",
     "pattern": "^((?:(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?:([A-Za-z]{2,3}(-(?:[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-(?:[A-Za-z]{4}))?(-(?:[A-Za-z]{2}|[0-9]{3}))?(-(?:[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-(?:[0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(?:x(-[A-Za-z0-9]{1,8})+))?)|(?:x(-[A-Za-z0-9]{1,8})+))$"

--- a/schema/module/bcp.schema.json
+++ b/schema/module/bcp.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://w3c.github.io/pub-manifest/schema/module/bcp.schema.json",
+    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/bcp.schema.json",
     "title": "BCP47 Language tag",
     "type": "string",
     "pattern": "^((?:(en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang))|((?:([A-Za-z]{2,3}(-(?:[A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-(?:[A-Za-z]{4}))?(-(?:[A-Za-z]{2}|[0-9]{3}))?(-(?:[A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-(?:[0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(?:x(-[A-Za-z0-9]{1,8})+))?)|(?:x(-[A-Za-z0-9]{1,8})+))$"

--- a/schema/module/context.schema.json
+++ b/schema/module/context.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/context.schema.json",
+	"$id": "https://www.w3.org/ns/pub-schema/manifest/module/context.schema.json",
 	"title": "Publication Contexts",
 	"type": "array",
 	"items": [
@@ -20,7 +20,7 @@
 				"type": "object",
 				"properties": {
 					"language": {
-						"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/bcp.schema.json"
+						"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/bcp.schema.json"
 					},
 					"direction": false
 				},
@@ -41,7 +41,7 @@
 				"type": "object",
 				"properties": {
 					"language": {
-						"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/bcp.schema.json"
+						"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/bcp.schema.json"
 					},
 					"direction": {
 						"type": "string",

--- a/schema/module/context.schema.json
+++ b/schema/module/context.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://w3c.github.io/pub-manifest/schema/module/context.schema.json",
+	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/context.schema.json",
 	"title": "Publication Contexts",
 	"type": "array",
 	"items": [
@@ -20,7 +20,7 @@
 				"type": "object",
 				"properties": {
 					"language": {
-						"$ref": "https://w3c.github.io/pub-manifest/schema/module/bcp.schema.json"
+						"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/bcp.schema.json"
 					},
 					"direction": false
 				},
@@ -41,7 +41,7 @@
 				"type": "object",
 				"properties": {
 					"language": {
-						"$ref": "https://w3c.github.io/pub-manifest/schema/module/bcp.schema.json"
+						"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/bcp.schema.json"
 					},
 					"direction": {
 						"type": "string",

--- a/schema/module/contributor-object.schema.json
+++ b/schema/module/contributor-object.schema.json
@@ -1,14 +1,14 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/contributor-object.schema.json",
+    "$id": "https://www.w3.org/ns/pub-schema/manifest/module/contributor-object.schema.json",
     "title": "Contributor Object",
     "type": "object",
     "properties": {
         "name": {
-            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/localizable.schema.json"
         },
         "id": {
-            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/url.schema.json"
         },
         "type": {
             "oneOf": [
@@ -35,7 +35,7 @@
             ]
         },
         "url": {
-        	"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json" 
+        	"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/url.schema.json" 
         },
         "identifier": {
         	"type": "array",

--- a/schema/module/contributor-object.schema.json
+++ b/schema/module/contributor-object.schema.json
@@ -1,14 +1,14 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://w3c.github.io/pub-manifest/schema/module/contributor-object.schema.json",
+    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/contributor-object.schema.json",
     "title": "Contributor Object",
     "type": "object",
     "properties": {
         "name": {
-            "$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable.schema.json"
         },
         "id": {
-            "$ref": "https://w3c.github.io/pub-manifest/schema/module/url.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json"
         },
         "type": {
             "oneOf": [
@@ -35,7 +35,7 @@
             ]
         },
         "url": {
-        	"$ref": "https://w3c.github.io/pub-manifest/schema/module/url.schema.json" 
+        	"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json" 
         },
         "identifier": {
         	"type": "array",

--- a/schema/module/contributor.schema.json
+++ b/schema/module/contributor.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json",
+    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json",
     "title": "Contributor",
     "anyOf": [
         {
@@ -14,13 +14,13 @@
                         "type": "string"
                     },
                     {
-                        "$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor-object.schema.json"
+                        "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor-object.schema.json"
                     }
                 ]
             }
         },
         {
-            "$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor-object.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor-object.schema.json"
         }
     ]
 }

--- a/schema/module/contributor.schema.json
+++ b/schema/module/contributor.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json",
+    "$id": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json",
     "title": "Contributor",
     "anyOf": [
         {
@@ -14,13 +14,13 @@
                         "type": "string"
                     },
                     {
-                        "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor-object.schema.json"
+                        "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor-object.schema.json"
                     }
                 ]
             }
         },
         {
-            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor-object.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor-object.schema.json"
         }
     ]
 }

--- a/schema/module/date.schema.json
+++ b/schema/module/date.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/date.schema.json",
+	"$id": "https://www.w3.org/ns/pub-schema/manifest/module/date.schema.json",
 	"title": "Dates",
 	"type": "string",
 	"anyOf": [

--- a/schema/module/date.schema.json
+++ b/schema/module/date.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://w3c.github.io/pub-manifest/schema/module/date.schema.json",
+	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/date.schema.json",
 	"title": "Dates",
 	"type": "string",
 	"anyOf": [

--- a/schema/module/duration.schema.json
+++ b/schema/module/duration.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/duration.schema.json",
+	"$id": "https://www.w3.org/ns/pub-schema/manifest/module/duration.schema.json",
 	"title": "Duration",
 	"type": "string",
 	"pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"

--- a/schema/module/duration.schema.json
+++ b/schema/module/duration.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://w3c.github.io/pub-manifest/schema/module/duration.schema.json",
+	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/duration.schema.json",
 	"title": "Duration",
 	"type": "string",
 	"pattern": "^P(?!$)((\\d+Y)|(\\d+\\.\\d+Y$))?((\\d+M)|(\\d+\\.\\d+M$))?((\\d+W)|(\\d+\\.\\d+W$))?((\\d+D)|(\\d+\\.\\d+D$))?(T(?=\\d)((\\d+H)|(\\d+\\.\\d+H$))?((\\d+M)|(\\d+\\.\\d+M$))?(\\d+(\\.\\d+)?S)?)??$"

--- a/schema/module/item-lists.schema.json
+++ b/schema/module/item-lists.schema.json
@@ -1,15 +1,15 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/item-lists.schema.json",
+	"$id": "https://www.w3.org/ns/pub-schema/manifest/module/item-lists.schema.json",
 	"title": "Lists of ItemList",
 	"oneOf": [
 		{
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/ItemList.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/ItemList.schema.json"
 		},
 		{
 			"type": "array",
 			"items": {
-				"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/ItemList.schema.json"
+				"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/ItemList.schema.json"
 			}
 		}
 	]

--- a/schema/module/item-lists.schema.json
+++ b/schema/module/item-lists.schema.json
@@ -1,15 +1,15 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://w3c.github.io/pub-manifest/schema/module/item-lists.schema.json",
+	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/item-lists.schema.json",
 	"title": "Lists of ItemList",
 	"oneOf": [
 		{
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/ItemList.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/ItemList.schema.json"
 		},
 		{
 			"type": "array",
 			"items": {
-				"$ref": "https://w3c.github.io/pub-manifest/schema/module/ItemList.schema.json"
+				"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/ItemList.schema.json"
 			}
 		}
 	]

--- a/schema/module/language.schema.json
+++ b/schema/module/language.schema.json
@@ -1,15 +1,15 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/language.schema.json",
+	"$id": "https://www.w3.org/ns/pub-schema/manifest/module/language.schema.json",
 	"title": "Languages",
 	"oneOf": [
 		{
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/bcp.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/bcp.schema.json"
 		},
 		{
 			"type": "array",
 			"items": {
-				"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/bcp.schema.json"
+				"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/bcp.schema.json"
 			}		
 		}
 	]

--- a/schema/module/language.schema.json
+++ b/schema/module/language.schema.json
@@ -1,15 +1,15 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://w3c.github.io/pub-manifest/schema/module/language.schema.json",
+	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/language.schema.json",
 	"title": "Languages",
 	"oneOf": [
 		{
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/bcp.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/bcp.schema.json"
 		},
 		{
 			"type": "array",
 			"items": {
-				"$ref": "https://w3c.github.io/pub-manifest/schema/module/bcp.schema.json"
+				"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/bcp.schema.json"
 			}		
 		}
 	]

--- a/schema/module/link.schema.json
+++ b/schema/module/link.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/link.schema.json",
+    "$id": "https://www.w3.org/ns/pub-schema/manifest/module/link.schema.json",
     "title": "Publication Links",
     "type": "object",
     "properties": {
@@ -22,13 +22,13 @@
             ]
         },
         "url": {
-            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/url.schema.json"
         },
         "encodingFormat": {
             "type": "string"
         },
         "name": {
-            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/localizable.schema.json"
         },
         "description": {
             "anyOf": [
@@ -36,7 +36,7 @@
                     "type": "string"
                 },
                 {
-                    "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable-object.schema.json"
+                    "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/localizable-object.schema.json"
                 }
             ]
         },
@@ -53,10 +53,10 @@
             "type": "string"
         },
         "duration": {
-        	"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/duration.schema.json"
+        	"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/duration.schema.json"
         },
         "alternate": {
-        	"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/resource.categorization.schema.json"
+        	"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/resource.categorization.schema.json"
         }
     },
     "required": [

--- a/schema/module/link.schema.json
+++ b/schema/module/link.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://w3c.github.io/pub-manifest/schema/module/link.schema.json",
+    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/link.schema.json",
     "title": "Publication Links",
     "type": "object",
     "properties": {
@@ -22,13 +22,13 @@
             ]
         },
         "url": {
-            "$ref": "https://w3c.github.io/pub-manifest/schema/module/url.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json"
         },
         "encodingFormat": {
             "type": "string"
         },
         "name": {
-            "$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable.schema.json"
         },
         "description": {
             "anyOf": [
@@ -36,7 +36,7 @@
                     "type": "string"
                 },
                 {
-                    "$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable-object.schema.json"
+                    "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable-object.schema.json"
                 }
             ]
         },
@@ -53,10 +53,10 @@
             "type": "string"
         },
         "duration": {
-        	"$ref": "https://w3c.github.io/pub-manifest/schema/module/duration.schema.json"
+        	"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/duration.schema.json"
         },
         "alternate": {
-        	"$ref": "https://w3c.github.io/pub-manifest/schema/module/resource.categorization.schema.json"
+        	"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/resource.categorization.schema.json"
         }
     },
     "required": [

--- a/schema/module/localizable-object.schema.json
+++ b/schema/module/localizable-object.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://w3c.github.io/pub-manifest/schema/module/localizable-object.schema.json",
+    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/localizable-object.schema.json",
     "title": "Localizable String Object",
     "type": "object",
     "properties": {
@@ -8,7 +8,7 @@
             "type": "string"
         },
         "language": {
-            "$ref": "https://w3c.github.io/pub-manifest/schema/module/bcp.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/bcp.schema.json"
         }
     },
     "required": [

--- a/schema/module/localizable-object.schema.json
+++ b/schema/module/localizable-object.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/localizable-object.schema.json",
+    "$id": "https://www.w3.org/ns/pub-schema/manifest/module/localizable-object.schema.json",
     "title": "Localizable String Object",
     "type": "object",
     "properties": {
@@ -8,7 +8,7 @@
             "type": "string"
         },
         "language": {
-            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/bcp.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/bcp.schema.json"
         }
     },
     "required": [

--- a/schema/module/localizable.schema.json
+++ b/schema/module/localizable.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://w3c.github.io/pub-manifest/schema/module/localizable.schema.json",
+    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/localizable.schema.json",
     "title": "Localizable String or Object",
     "anyOf": [
         {
@@ -14,13 +14,13 @@
                         "type": "string"
                     },
                     {
-                        "$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable-object.schema.json"
+                        "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable-object.schema.json"
                     }
                 ]
             }
         },
         {
-            "$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable-object.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable-object.schema.json"
         }
     ]
 }

--- a/schema/module/localizable.schema.json
+++ b/schema/module/localizable.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/localizable.schema.json",
+    "$id": "https://www.w3.org/ns/pub-schema/manifest/module/localizable.schema.json",
     "title": "Localizable String or Object",
     "anyOf": [
         {
@@ -14,13 +14,13 @@
                         "type": "string"
                     },
                     {
-                        "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable-object.schema.json"
+                        "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/localizable-object.schema.json"
                     }
                 ]
             }
         },
         {
-            "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable-object.schema.json"
+            "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/localizable-object.schema.json"
         }
     ]
 }

--- a/schema/module/resource.categorization.schema.json
+++ b/schema/module/resource.categorization.schema.json
@@ -1,15 +1,15 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://w3c.github.io/pub-manifest/schema/module/resource.categorization.schema.json",
+    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/resource.categorization.schema.json",
     "title": "Resource Categorization",
     "oneOf": [
         {
             "oneOf" : [
                 {
-                    "$ref": "https://w3c.github.io/pub-manifest/schema/module/url.schema.json"
+                    "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json"
                 },
                 {
-                    "$ref": "https://w3c.github.io/pub-manifest/schema/module/link.schema.json"
+                    "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/link.schema.json"
                 }
             ]
         },
@@ -18,10 +18,10 @@
             "items": {
                 "anyOf": [
                     {
-                        "$ref": "https://w3c.github.io/pub-manifest/schema/module/url.schema.json"
+                        "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json"
                     },
                     {
-                        "$ref": "https://w3c.github.io/pub-manifest/schema/module/link.schema.json"
+                        "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/link.schema.json"
                     }
                 ]
             },

--- a/schema/module/resource.categorization.schema.json
+++ b/schema/module/resource.categorization.schema.json
@@ -1,15 +1,15 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/resource.categorization.schema.json",
+    "$id": "https://www.w3.org/ns/pub-schema/manifest/module/resource.categorization.schema.json",
     "title": "Resource Categorization",
     "oneOf": [
         {
             "oneOf" : [
                 {
-                    "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json"
+                    "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/url.schema.json"
                 },
                 {
-                    "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/link.schema.json"
+                    "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/link.schema.json"
                 }
             ]
         },
@@ -18,10 +18,10 @@
             "items": {
                 "anyOf": [
                     {
-                        "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json"
+                        "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/url.schema.json"
                     },
                     {
-                        "$ref": "https://www.w3.org/ns/pub-manifest/schema/module/link.schema.json"
+                        "$ref": "https://www.w3.org/ns/pub-schema/manifest/module/link.schema.json"
                     }
                 ]
             },

--- a/schema/module/strings.schema.json
+++ b/schema/module/strings.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/strings.schema.json",
+	"$id": "https://www.w3.org/ns/pub-schema/manifest/module/strings.schema.json",
 	"title": "Unique strings",
 	"type": [
 		"string",

--- a/schema/module/strings.schema.json
+++ b/schema/module/strings.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://w3c.github.io/pub-manifest/schema/module/strings.schema.json",
+	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/strings.schema.json",
 	"title": "Unique strings",
 	"type": [
 		"string",

--- a/schema/module/url.schema.json
+++ b/schema/module/url.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://w3c.github.io/pub-manifest/schema/module/url.schema.json",
+    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json",
     "title": "URL",
     "type": "string",
     "format": "uri-reference"

--- a/schema/module/url.schema.json
+++ b/schema/module/url.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json",
+    "$id": "https://www.w3.org/ns/pub-schema/manifest/module/url.schema.json",
     "title": "URL",
     "type": "string",
     "format": "uri-reference"

--- a/schema/module/urls.schema.json
+++ b/schema/module/urls.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/urls.schema.json",
+	"$id": "https://www.w3.org/ns/pub-schema/manifest/module/urls.schema.json",
 	"title": "URLs",
 	"oneOf": [
 		{

--- a/schema/module/urls.schema.json
+++ b/schema/module/urls.schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://w3c.github.io/pub-manifest/schema/module/urls.schema.json",
+	"$id": "https://www.w3.org/ns/pub-manifest/schema/module/urls.schema.json",
 	"title": "URLs",
 	"oneOf": [
 		{

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -1,11 +1,11 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://www.w3.org/ns/pub-manifest/schema/publication.schema.json",
+	"$id": "https://www.w3.org/ns/pub-schema/manifest/publication.schema.json",
 	"title": "Publication Manifest",
 	"type": "object",
 	"properties": {
 		"@context": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/context.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/context.schema.json"
 		},
 		"type": {
 			"type": [
@@ -19,12 +19,12 @@
 		"conformsTo" : {
 			"oneOf": [
 				{
-					"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json"
+					"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/url.schema.json"
 				},
 				{
 					"type": "array",
 					"items": {
-						"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json"
+						"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/url.schema.json"
 					}		
 				}
 			]
@@ -36,85 +36,85 @@
 			"type": "boolean"
 		},
 		"accessMode": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/strings.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/strings.schema.json"
 		},
 		"accessModeSufficient": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/item-lists.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/item-lists.schema.json"
 		},
 		"accessibilityFeature": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/strings.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/strings.schema.json"
 		},
 		"accessibilityHazard": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/strings.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/strings.schema.json"
 		},
 		"accessibilitySummary": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/localizable.schema.json"
 		},
 		"artist": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"author": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"colorist": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"contributor": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"creator": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"editor": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"illustrator": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"inker": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"letterer": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"penciler": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"publisher": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"readBy": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"translator": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
 		"url": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/urls.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/urls.schema.json"
 		},
 		"duration": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/duration.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/duration.schema.json"
 		},
 		"inLanguage": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/language.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/language.schema.json"
 		},
 		"dateModified": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/date.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/date.schema.json"
 		},
 		"datePublished": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/date.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/date.schema.json"
 		},
 		"name": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/localizable.schema.json"
 		},
 		"readingOrder": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/resource.categorization.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/resource.categorization.schema.json"
 		},
 		"resources": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/resource.categorization.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/resource.categorization.schema.json"
 		},
 		"links": {
-			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/resource.categorization.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/resource.categorization.schema.json"
 		}
 	},
 	"required": [

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -1,11 +1,11 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://w3c.github.io/pub-manifest/schema/publication.schema.json",
+	"$id": "https://www.w3.org/ns/pub-manifest/schema/publication.schema.json",
 	"title": "Publication Manifest",
 	"type": "object",
 	"properties": {
 		"@context": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/context.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/context.schema.json"
 		},
 		"type": {
 			"type": [
@@ -19,12 +19,12 @@
 		"conformsTo" : {
 			"oneOf": [
 				{
-					"$ref": "https://w3c.github.io/pub-manifest/schema/module/url.schema.json"
+					"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json"
 				},
 				{
 					"type": "array",
 					"items": {
-						"$ref": "https://w3c.github.io/pub-manifest/schema/module/url.schema.json"
+						"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/url.schema.json"
 					}		
 				}
 			]
@@ -36,85 +36,85 @@
 			"type": "boolean"
 		},
 		"accessMode": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/strings.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/strings.schema.json"
 		},
 		"accessModeSufficient": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/item-lists.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/item-lists.schema.json"
 		},
 		"accessibilityFeature": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/strings.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/strings.schema.json"
 		},
 		"accessibilityHazard": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/strings.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/strings.schema.json"
 		},
 		"accessibilitySummary": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable.schema.json"
 		},
 		"artist": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"author": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"colorist": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"contributor": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"creator": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"editor": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"illustrator": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"inker": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"letterer": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"penciler": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"publisher": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"readBy": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"translator": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/contributor.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/contributor.schema.json"
 		},
 		"url": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/urls.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/urls.schema.json"
 		},
 		"duration": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/duration.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/duration.schema.json"
 		},
 		"inLanguage": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/language.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/language.schema.json"
 		},
 		"dateModified": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/date.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/date.schema.json"
 		},
 		"datePublished": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/date.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/date.schema.json"
 		},
 		"name": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/localizable.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/localizable.schema.json"
 		},
 		"readingOrder": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/resource.categorization.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/resource.categorization.schema.json"
 		},
 		"resources": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/resource.categorization.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/resource.categorization.schema.json"
 		},
 		"links": {
-			"$ref": "https://w3c.github.io/pub-manifest/schema/module/resource.categorization.schema.json"
+			"$ref": "https://www.w3.org/ns/pub-manifest/schema/module/resource.categorization.schema.json"
 		}
 	},
 	"required": [


### PR DESCRIPTION
As [resolved on the telecon today](https://www.w3.org/publishing/groups/publ-wg/Meetings/Minutes/2020/2020-07-27-pwg), updating the URLs to w3c addresses to fix #226.

Before merging, though, we'll need to make sure the redirects are up and running.

Will open a similar PR for audiobooks shortly.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/228.html" title="Last updated on Jul 29, 2020, 2:12 PM UTC (30a6939)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/228/a896d5f...30a6939.html" title="Last updated on Jul 29, 2020, 2:12 PM UTC (30a6939)">Diff</a>