### PR TITLE
reading order is required in the spec

### DIFF
--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -119,6 +119,7 @@
 	},
 	"required": [
 		"@context",
-		"conformsTo"
+		"conformsTo",
+		"readingOrder"
 	]
 }


### PR DESCRIPTION
I spotted that the audiobook schema has readingOrder required, not the generic pub-manifest schema. 
But readingOrder is required by the pub-manifest spec.