### PR TITLE
switch iso8601 references to iso8601-1

### DIFF
--- a/common/js/biblio.js
+++ b/common/js/biblio.js
@@ -131,5 +131,13 @@ var localBiblio = {
     "mfrel": {
     	"title": "Microformats Wiki: existing rel values. Microformats.",
     	"href": "http://microformats.org/wiki/existing-rel-values#HTML5_link_type_extensions"
+    },
+    "iso8601-1": {
+        "href": "https://www.iso.org/standard/70907.html",
+        "publisher": "International Organization for Standardization (ISO)",
+        "date": "2019",
+        "status": "ISO 8601-1:2019",
+        "title": "Date and time — Representations for information interchange — Part 1: Basic rules. ISO 8601-1:2019.",
+        "isoNumber": "ISO 8601-1:2019"
     }
 }

--- a/index.html
+++ b/index.html
@@ -731,7 +731,7 @@
 										<code>duration</code>
 									</td>
 									<td>Overall duration of a time-based media resource. OPTIONAL</td>
-									<td>Duration value as defined by&#160;[[!iso8601]].</td>
+									<td>Duration value as defined by&#160;[[!iso8601-1]].</td>
 									<td>
 										<a href="#value-literal">Literal</a>
 									</td>
@@ -981,10 +981,9 @@
 
 					<p>The global language and base direction declarations for natural language manifest properties are
 						set in the <a href="#manifest-context">context</a> using the <a
-							href="https://www.w3.org/TR/json-ld/#syntax-tokens-and-keywords"
-								><code>language</code></a> and <a
-									href="https://www.w3.org/TR/json-ld/#syntax-tokens-and-keywords"
-								><code>direction</code></a> keywords&#160;[[!json-ld11]], respectively. These values are
+							href="https://www.w3.org/TR/json-ld/#syntax-tokens-and-keywords"><code>language</code></a>
+						and <a href="https://www.w3.org/TR/json-ld/#syntax-tokens-and-keywords"
+							><code>direction</code></a> keywords&#160;[[!json-ld11]], respectively. These values are
 						used to expand simple string values into <a href="#value-localizable-string">localizable
 							strings</a> during the <a href="#manifest-processing">processing of the manifest</a>, as
 						well as to provide a language and the base direction for localizable strings that omit one.</p>
@@ -1764,7 +1763,7 @@
 										<code>duration</code>
 									</td>
 									<td>Overall duration of a time-based publication.</td>
-									<td>Duration value as defined by&#160;[[!iso8601]].</td>
+									<td>Duration value as defined by&#160;[[!iso8601-1]].</td>
 									<td>
 										<a href="#value-literal">Literal</a>
 									</td>
@@ -1816,7 +1815,7 @@
 									<td>A <a href="https://schema.org/Date"><code>Date</code></a> or <a
 											href="https://schema.org/DateTime"><code>DateTime</code></a>
 										value&#160;[[!schema.org]], both expressed in ISO 8601 Date, or Date Time
-										formats, respectively&#160;[[!iso8601]].</td>
+										formats, respectively&#160;[[!iso8601-1]].</td>
 									<td>
 										<a href="#value-literal">Literal</a>
 									</td>
@@ -1864,7 +1863,7 @@
 									<td>Creation date of the publication.</td>
 									<td>A <a href="https://schema.org/Date"><code>Date</code></a> or <a
 											href="https://schema.org/DateTime"><code>DateTime</code></a>, both expressed
-										in ISO 8601 Date, or Date Time formats, respectively&#160;[[!iso8601]].</td>
+										in ISO 8601 Date, or Date Time formats, respectively&#160;[[!iso8601-1]].</td>
 									<td>
 										<a href="#value-literal">Literal</a>
 									</td>
@@ -3615,21 +3614,21 @@
 
 						<li id="validate-duration">
 							<p>(<a href="#duration"></a>) If <var>data["duration"]</var> is set and is not a valid
-								duration value, per&#160;[[!iso8601]], <a>validation error</a>, <a
+								duration value, per&#160;[[!iso8601-1]], <a>validation error</a>, <a
 									href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 								<var>data["duration"]</var>.</p>
 						</li>
 
 						<li id="validate-last-mod">
 							<p>(<a href="#last-modification-date"></a>) If <var>data["dateModified"]</var> is set and is
-								not a valid date or date-time per&#160;[[!iso8601]], <a>validation error</a>, <a
+								not a valid date or date-time per&#160;[[!iso8601-1]], <a>validation error</a>, <a
 									href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 								<var>data["dateModified"]</var>.</p>
 						</li>
 
 						<li id="validate-pub-date">
 							<p>(<a href="#publication-date"></a>) If <var>data["datePublished"]</var> is set and is not
-								a valid date or date-time per&#160;[[!iso8601]], <a>validation error</a>, <a
+								a valid date or date-time per&#160;[[!iso8601-1]], <a>validation error</a>, <a
 									href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 								<var>data["datePublished"]</var>.</p>
 						</li>
@@ -3969,9 +3968,9 @@
 									</li>
 									<li>
 										<p>if <a href="#linkedresource-duration"><var>resource["duration"]</var></a> is
-											set and is not a valid duration value, per&#160;[[!iso8601]], <a>validation
-												error</a>, <a href="https://infra.spec.whatwg.org/#map-remove"
-												>remove</a>
+											set and is not a valid duration value, per&#160;[[!iso8601-1]],
+												<a>validation error</a>, <a
+												href="https://infra.spec.whatwg.org/#map-remove">remove</a>
 											<var>resource["duration"]</var>.</p>
 									</li>
 								</ul>

--- a/index.html
+++ b/index.html
@@ -5231,9 +5231,17 @@ dictionary LocalizableString {
 			<h2>Change Log</h2>
 
 			<section id="change-log-latest">
-				<h3>Substantive changes since the <a href="https://www.w3.org/TR/2020/CR-pub-manifest-20200317/"
+				<h3>Substantive changes since the <a href="https://www.w3.org/TR/2020/CR-pub-manifest-20200730/"
 						>previous version</a></h3>
 
+				<ul>
+					<li>4-Sept-2020: Updated the reference to ISO 8601:2004 to the revised ISO 8601-1:2019. See <a
+							href="https://github.com/w3c/audiobooks/issues/65">issue 65</a> (Audiobooks tracker).</li>
+				</ul>
+			</section>
+
+			<section id="change-log-older">
+				<h3>Other substantive changes since Candidate Recommendation</h3>
 				<ul>
 					<li>27-July-2020: Updated the reference schema URL to a W3C address. See <a
 							href="https://github.com/w3c/pub-manifest/issues/226">issue 226</a>.</li>
@@ -5247,12 +5255,6 @@ dictionary LocalizableString {
 					<li>15-Apr-2020: Removed the bullet from the LocalizableString definition allowing an array of
 						values, as this creates an invalid nesting of arrays when paired with the value categories. See
 							<a href="https://github.com/w3c/pub-manifest/issues/205">issue 205</a>.</li>
-				</ul>
-			</section>
-
-			<section id="change-log-older">
-				<h3>Other substantive changes since Candidate Recommendation</h3>
-				<ul>
 					<li>12-Feb-2020: The prose requirements for the resource that links to the manifest to be a
 						publication resource and to be automatically added to the reading order (when one is not
 						present) were restored to align with the algorithm steps. An additional check was also included


### PR DESCRIPTION
This PR updates the references to ISO 8601 for duration values to the new Part 1 version of the standard released last year.

Fixes https://github.com/w3c/audiobooks/issues/65 originally raised in the Audiobooks tracker.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/231.html" title="Last updated on Sep 4, 2020, 1:52 PM UTC (1a2db32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/231/2bd587f...1a2db32.html" title="Last updated on Sep 4, 2020, 1:52 PM UTC (1a2db32)">Diff</a>