### PR TITLE
Fix map key

### DIFF
--- a/index.html
+++ b/index.html
@@ -2954,7 +2954,7 @@
 					</li>
 
 					<li id="processing-context">
-						<p>(<a href="#manifest-context"></a>) If <var>manifest["context"]</var> is not set to a <a
+						<p>(<a href="#manifest-context"></a>) If <var>manifest["@context"]</var> is not set to a <a
 								href="https://infra.spec.whatwg.org/#list">list</a>, or the first and second <a
 								href="https://infra.spec.whatwg.org/#list-item">items</a> in
 								<var>manifest["@context"]</var> are not the <a


### PR DESCRIPTION
I believe it should be `@context`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/naglis/pub-manifest/pull/232.html" title="Last updated on Sep 10, 2020, 9:05 PM UTC (a1512d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/232/50cbb97...naglis:a1512d6.html" title="Last updated on Sep 10, 2020, 9:05 PM UTC (a1512d6)">Diff</a>