### PR TITLE
Fix to use correct variable name

### DIFF
--- a/index.html
+++ b/index.html
@@ -3487,7 +3487,7 @@
 											href="https://infra.spec.whatwg.org/#ordered-map">map</a>:</p>
 									<ol>
 										<li>
-											<p>if <var>item["type"]</var> is set and includes a <a>recognized type</a>,
+											<p>if <var>normalized["type"]</var> is set and includes a <a>recognized type</a>,
 													<a href="https://infra.spec.whatwg.org/#map-iterate">for each</a>
 												<var>key</var> → <var>keyValue</var> of <var>normalized</var>, set
 													<var>key</var> to the result of running <a


### PR DESCRIPTION
From the context (`normalized` should be a map here), I think it should be `normalized`, not `item`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/naglis/pub-manifest/pull/233.html" title="Last updated on Sep 10, 2020, 11:54 PM UTC (a8255c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/233/50cbb97...naglis:a8255c7.html" title="Last updated on Sep 10, 2020, 11:54 PM UTC (a8255c7)">Diff</a>