### PR TITLE
Fix variable in recursive normalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -3473,7 +3473,7 @@
 													href="#processing-normalize">normalize data</a>, when successful,
 												given <var>key</var>, <var>keyValue</var>, <var>lang</var>,
 													<var>dir</var>, <var>base</var> and using
-													<var>keyValue["type"]</var> as the context. If failure is returned,
+													<var>item["type"]</var> as the context. If failure is returned,
 													<a href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 												<var>key</var> from <var>item</var>.</p>
 										</li>
@@ -3494,7 +3494,7 @@
 													href="#processing-normalize">normalize data</a>, when successful,
 												given <var>key</var>, <var>keyValue</var>, <var>lang</var>,
 													<var>dir</var>, <var>base</var> and using
-													<var>keyValue["type"]</var> as the context. If failure is returned,
+													<var>normalized["type"]</var> as the context. If failure is returned,
 													<a href="https://infra.spec.whatwg.org/#list-remove">remove</a>
 												<var>key</var> from <var>normalized</var>.</p>
 										</li>


### PR DESCRIPTION
At 7.4.1 step 9.a.i, if `normalized` is a list containing `item` map, e.g.:

```json
[
    {
        "type": [
            "Person"
        ],
        "name": "Herman Melville"
    }
]
```

it seems that context for the recursive normalize data call should be `item["type"]`, not `keyValue["item"]`. In this case, context would be `Person`.

Same applies for step 9.b.i.

It appears `item["type"]` is being used in the reference implementation:

https://github.com/w3c/pub-manifest/blob/9a17073f65c5bae1e120933a9676250016b70148/experiments/manifest-to-internal-processor/manifestProcessor.js#L624


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/naglis/pub-manifest/pull/234.html" title="Last updated on Sep 12, 2020, 10:41 PM UTC (3b6fe5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/234/9a17073...naglis:3b6fe5a.html" title="Last updated on Sep 12, 2020, 10:41 PM UTC (3b6fe5a)">Diff</a>