### PR TITLE
Fix variable name

### DIFF
--- a/index.html
+++ b/index.html
@@ -4061,7 +4061,7 @@
 											<var>key</var> → <var>keyValue</var> of <var>value</var>, if <var>key</var>
 											has an expected value category, set <var>key</var> to the result of running
 												<a>verify value category</a> given <var>key</var>, <var>keyValue</var>
-											and using <var>item["type"]</var> as the context. If the result of
+											and using <var>value["type"]</var> as the context. If the result of
 											processing <var>value</var> is an empty <a
 												href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>validation
 												error</a>, return failure.</p>


### PR DESCRIPTION
Similar to #233, I think it should be `value["type"]` here, instead of `item["type"]`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/naglis/pub-manifest/pull/239.html" title="Last updated on Sep 25, 2020, 11:42 AM UTC (63cfb6f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/239/1972c1f...naglis:63cfb6f.html" title="Last updated on Sep 25, 2020, 11:42 AM UTC (63cfb6f)">Diff</a>