### PR TITLE
Fix typo in key name

### DIFF
--- a/index.html
+++ b/index.html
@@ -4302,7 +4302,7 @@
 
 						<li id="processing-defaults-linking-resource">
 							<p>(<a href="#manifest-link"></a>) If <a data-cite="!dom#concept-document-url"
-										><var>document.URL</var></a> is set and <var>data["uniqueResource"]</var> does
+										><var>document.URL</var></a> is set and <var>data["uniqueResources"]</var> does
 								not <a href="https://infra.spec.whatwg.org/#list-contain">contain</a>
 								<var>document.URL</var>, <a>validation error</a>.</p>
 							<details>


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/naglis/pub-manifest/pull/240.html" title="Last updated on Sep 26, 2020, 12:37 AM UTC (e5e3969)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/240/1972c1f...naglis:e5e3969.html" title="Last updated on Sep 26, 2020, 12:37 AM UTC (e5e3969)">Diff</a>