### PR TITLE
Unify map key syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -4970,7 +4970,7 @@ dictionary LocalizableString {
 												<var>branches</var> and set <var>current_toc_node</var> to it.</p>
 									</li>
 									<li>
-										<p>Otherwise, if <var>toc.entries</var> contains an empty <a
+										<p>Otherwise, if <var>toc["entries"]</var> contains an empty <a
 												href="https://infra.spec.whatwg.org/#list">list</a>, set it to <a
 												href="https://infra.spec.whatwg.org/#nulls">null</a>.</p>
 									</li>
@@ -4979,7 +4979,7 @@ dictionary LocalizableString {
 									<summary>Explanation</summary>
 									<p>This step resets <var>current_toc_node</var> back to the parent object after all
 										of its child branches have been processed.</p>
-									<p>If there are no branches in the stack, the <var>toc.entries</var> is set to null
+									<p>If there are no branches in the stack, the <var>toc["entries"]</var> is set to null
 										if it doesn't contain any items (to avoid processing any further lists at the
 										root level).</p>
 								</details>


### PR DESCRIPTION
Here dot notation is used, however bracket notation is used elsewhere throughout the document, so I think it is worth to make it consistent.

Fixes #260 

<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/naglis/pub-manifest/pull/242.html" title="Last updated on Feb 4, 2021, 3:28 PM UTC (c04e298)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/242/f63fe7c...naglis:c04e298.html" title="Last updated on Feb 4, 2021, 3:28 PM UTC (c04e298)">Diff</a>