### PR TITLE
Fix bidi example

### DIFF
--- a/index.html
+++ b/index.html
@@ -462,8 +462,8 @@
 							<p dir="rtl">HTML היא שפת סימון.</p>
 							<p>Note that the <var>value</var> field in the example represents the text as it is stored
 								in memory, hence the discrepancy between it and the two renderings depicted here. Text
-								editors might also display the text differently (e.g., using the Unicode Bidirectional
-								Algorithm only).</p>
+								editors might also display the JSON value differently (e.g., using the Unicode
+								Bidirectional Algorithm only).</p>
 							<p>See also the [[string-meta]] document for further explanations and examples.</p>
 						</div>
 					</section>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,11 @@
 					repoURL: "https://github.com/w3c/pub-manifest/",
 					branch: "master"
 				},
-				localBiblio: localBiblio
+				localBiblio: localBiblio,
+				alternateFormats: [{
+				    "uri": "pub-manifest.epub",
+				    "label": "EPUB"
+				}]
 			};//]]>
 	  </script>
 		<style>

--- a/index.html
+++ b/index.html
@@ -446,10 +446,10 @@
 							<p> However, that would be incorrect. The extra <code>direction</code> value is necessary to
 								control the display to yield: </p>
 							<p dir="rtl">HTML היא שפת סימון.</p>
+							<p>(Note that the <var>value</var> field in the example represents the text as it is stored
+								in memory, hence the discrepancy between it and the two renderings depicted here.)</p>
 							<p>See also the [[string-meta]] document for further explanations and examples.</p>
 						</div>
-
-
 					</section>
 
 					<section id="value-entity">

--- a/index.html
+++ b/index.html
@@ -272,10 +272,14 @@
 
 				<ul>
 					<li>
-						<a href="#manifest-context"><code>context</code></a>
+						<a href="#manifest-context">
+							<code>context</code>
+						</a>
 					</li>
 					<li>
-						<a href="#profile-conformance"><code>conformsTo</code></a>
+						<a href="#profile-conformance">
+							<code>conformsTo</code>
+						</a>
 					</li>
 				</ul>
 
@@ -283,10 +287,14 @@
 
 				<ul>
 					<li>
-						<a href="#publication-types"><code>type</code></a>
+						<a href="#publication-types">
+							<code>type</code>
+						</a>
 					</li>
 					<li>
-						<a href="#canonical-identifier"><code>id</code></a>
+						<a href="#canonical-identifier">
+							<code>id</code>
+						</a>
 					</li>
 				</ul>
 
@@ -387,7 +395,9 @@
 									</td>
 									<td>The value of the localizable string. REQUIRED.</td>
 									<td>Text.</td>
-									<td><a href="#value-literal">Literal</a></td>
+									<td>
+										<a href="#value-literal">Literal</a>
+									</td>
 									<td>(None)</td>
 								</tr>
 								<tr>
@@ -397,7 +407,9 @@
 									<td>The language of the value. OPTIONAL.</td>
 									<td>A <a href="https://tools.ietf.org/html/bcp47#section-2.2.9">well-formed language
 											tag</a>&#160;[[!bcp47]].</td>
-									<td><a href="#value-literal">Literal</a></td>
+									<td>
+										<a href="#value-literal">Literal</a>
+									</td>
 									<td>(None)</td>
 								</tr>
 								<tr>
@@ -406,7 +418,9 @@
 									</td>
 									<td>The base direction of the value. OPTIONAL.</td>
 									<td><code>ltr</code> or <code>rtl</code></td>
-									<td><a href="#value-literal">Literal</a></td>
+									<td>
+										<a href="#value-literal">Literal</a>
+									</td>
 									<td>(None)</td>
 								</tr>
 							</tbody>
@@ -446,8 +460,10 @@
 							<p> However, that would be incorrect. The extra <code>direction</code> value is necessary to
 								control the display to yield: </p>
 							<p dir="rtl">HTML היא שפת סימון.</p>
-							<p>(Note that the <var>value</var> field in the example represents the text as it is stored
-								in memory, hence the discrepancy between it and the two renderings depicted here.)</p>
+							<p>Note that the <var>value</var> field in the example represents the text as it is stored
+								in memory, hence the discrepancy between it and the two renderings depicted here. Text
+								editors might also display the text differently (e.g., using the Unicode Bidirectional
+								Algorithm only).</p>
 							<p>See also the [[string-meta]] document for further explanations and examples.</p>
 						</div>
 					</section>
@@ -708,7 +724,8 @@
 									</td>
 									<td>A cryptographic hashing of the resource that allows its integrity to be
 										verified. OPTIONAL.</td>
-									<td><p>One or more whitespace-separated sets of <a
+									<td>
+										<p>One or more whitespace-separated sets of <a
 												href="https://www.w3.org/TR/SRI/#dfn-integrity-metadata">integrity
 												metadata</a>&#160;[[!sri]]. The value MUST conform to the <a
 												href="https://www.w3.org/TR/SRI/#the-integrity-attribute">metadata
@@ -1182,9 +1199,11 @@
 							<td>An <a href="https://url.spec.whatwg.org/#absolute-url-with-fragment-string"
 									>absolute-URL-with-fragment string</a>&#160;[[!url]].</td>
 							<td><a href="#value-array">Array</a> of <a href="#value-literal">Literals</a></td>
-							<td><a
+							<td>
+								<a
 									href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/conformsTo"
-									>conformsTo</a></td>
+									>conformsTo</a>
+							</td>
 						</tr>
 					</tbody>
 				</table>
@@ -1230,7 +1249,9 @@
 									</td>
 									<td>Indicates whether the book is an abridged edition.</td>
 									<td>Either <code>true</code> or <code>false</code>.</td>
-									<td><a href="#value-boolean">Boolean</a></td>
+									<td>
+										<a href="#value-boolean">Boolean</a>
+									</td>
 									<td>
 										<a href="https://schema.org/abridged"><code>abridged</code></a> (<a
 											href="https://schema.org/Book">Book</a>) </td>
@@ -1438,7 +1459,9 @@
 									</td>
 									<td>Preferred version of the publication.</td>
 									<td>A URL record&#160;[[!url]].</td>
-									<td><a href="#value-id">Identifier</a></td>
+									<td>
+										<a href="#value-id">Identifier</a>
+									</td>
 									<td>(None)</td>
 								</tr>
 							</tbody>
@@ -2851,7 +2874,9 @@
 		<section id="manifest-processing">
 			<h2>Processing a Manifest</h2>
 
-			<p><em>This section depends on the Infra Standard [[!infra]].</em></p>
+			<p>
+				<em>This section depends on the Infra Standard [[!infra]].</em>
+			</p>
 
 			<section id="processing-intro" class="informative">
 				<h3>Introduction</h3>
@@ -4482,7 +4507,9 @@ dictionary LocalizableString {
 		<section id="app-select-alternate" class="appendix">
 			<h3>Selecting an Alternate Resource</h3>
 
-			<p><em>This appendix depends on the Infra Standard [[!infra]].</em></p>
+			<p>
+				<em>This appendix depends on the Infra Standard [[!infra]].</em>
+			</p>
 
 			<p>To <dfn>select an alternate resource</dfn> for a <a><code>LinkedResource</code></a>
 				<var>resource</var>, run the following steps.</p>
@@ -4770,7 +4797,9 @@ dictionary LocalizableString {
 			<section id="app-toc-ua">
 				<h3>User Agent Processing</h3>
 
-				<p><em>This section depends on the Infra Standard [[!infra]].</em></p>
+				<p>
+					<em>This section depends on the Infra Standard [[!infra]].</em>
+				</p>
 
 				<p>This section defines an algorithm for extracting a table of contents from a <code>nav</code> element.
 					It is defined in terms of a walk over the nodes of a DOM tree, in <a
@@ -5203,8 +5232,8 @@ dictionary LocalizableString {
 								</p>
 								<details>
 									<summary>Explanation</summary>
-									<p>For all other elements, this step allows their descendant elements to continue
-										to be processed.</p>
+									<p>For all other elements, this step allows their descendant elements to continue to
+										be processed.</p>
 								</details>
 							</li>
 						</ol>
@@ -5293,7 +5322,9 @@ dictionary LocalizableString {
 					<dd>Links to a publication <a>manifest</a>. A manifest represents structured information about a
 						publication, such as informative metadata, a list of resources, and a default reading order. </dd>
 					<dt>Reference:</dt>
-					<dd><a href="https://www.w3.org/TR/pub-manifest/">https://www.w3.org/TR/pub-manifest</a></dd>
+					<dd>
+						<a href="https://www.w3.org/TR/pub-manifest/">https://www.w3.org/TR/pub-manifest</a>
+					</dd>
 					<dt>Notes:</dt>
 					<dd>Please refer to the steps in <a href="#manifest-discovery"></a> for details on how to access,
 						and <a href="#manifest-processing"></a> on how to process a <a>manifest</a>.</dd>
@@ -5497,7 +5528,9 @@ dictionary LocalizableString {
 						<td>
 							<code>id</code>
 						</td>
-						<td><a href="#canonical-identifier"></a></td>
+						<td>
+							<a href="#canonical-identifier"></a>
+						</td>
 					</tr>
 					<tr>
 						<td>
@@ -5623,7 +5656,9 @@ dictionary LocalizableString {
 						<td>
 							<code>url</code>
 						</td>
-						<td><a href="#address"></a></td>
+						<td>
+							<a href="#address"></a>
+						</td>
 					</tr>
 				</tbody>
 			</table>

--- a/index.html
+++ b/index.html
@@ -148,8 +148,8 @@
 					</dt>
 					<dd>
 						<p>Structural resources are key meta structures of the publication, such as the <a href="#cover"
-								>cover image</a>, <a href="#table-of-contents">table of contents</a>, and <a
-								href="#page-list">page list</a>.</p>
+								>cover image</a>, <a href="#contents">table of contents</a>, and <a href="#page-list"
+								>page list</a>.</p>
 					</dd>
 				</dl>
 			</section>
@@ -2080,7 +2080,7 @@
 							list</a>, and the <a>links</a>, as defined in this section. These lists contain references
 						to <a href="#informative-rel">informative resources</a> like the <a href="#privacy-policy"
 							>privacy policy</a>, and <a href="#structural-rel">structural resources</a> like the <a
-							href="#table-of-contents">table of contents</a>.</p>
+							href="#contents">table of contents</a>.</p>
 
 					<p class="note">It is not necessary to include a reference to the manifest in any of these
 						lists.</p>
@@ -4619,7 +4619,7 @@ dictionary LocalizableString {
 					in <a href="https://dom.spec.whatwg.org/#concept-tree-order">document tree order</a>&#160;[[!dom]]
 					with that <code>role</code> value. The element MAY be hidden from users.</p>
 
-				<p>The manifest SHOULD <a href="#table-of-contents">identify the resource</a> that contains the table of
+				<p>The manifest SHOULD <a href="#contents">identify the resource</a> that contains the table of
 					contents.</p>
 
 				<p>Although the content model of the <code>nav</code> element is not restricted, user agents will only

--- a/snapshot/index.html
+++ b/snapshot/index.html
@@ -1849,7 +1849,7 @@
 								<span class="example-title">: Set the language and the base direction of a string</span>
 							</div>
 							<pre aria-busy="false"><code class="hljs json">{
-    <span class="hljs-attr">"value"</span>     : <span class="hljs-string">"HTML היא שפת סימון."</span>,
+    <span class="hljs-attr">"value"</span>     : <span class="hljs-string">"<bdo dir="ltr">HTML היא שפת סימון.</bdo>"</span>,
     <span class="hljs-attr">"language"</span>  : <span class="hljs-string">"he"</span>,
     <span class="hljs-attr">"direction"</span> : <span class="hljs-string">"rtl"</span>
 }</code></pre>
@@ -1859,15 +1859,18 @@
 								<span>Note</span>
 							</div>
 							<div class="">
-								<p> If the base direction value were not set in the last example, the text would be
+								<p>If the base direction value were not set in the last example, the text would be
 									displayed, following the Unicode Bidirectional Algorithm&#160;[<cite><a
 											class="bibref" data-link-type="biblio" href="#bib-bidi"
 											title="Unicode Bidirectional Algorithm">bidi</a></cite>] and due to the
 									presence of a Latin character starting the string, as: </p>
 								<p dir="ltr">HTML היא שפת סימון.</p>
-								<p> However, that would be incorrect. The extra <code>direction</code> value is
-									necessary to control the display to yield: </p>
+								<p>However, that would be incorrect. The extra <code>direction</code> value is necessary
+									to control the display to yield: </p>
 								<p dir="rtl">HTML היא שפת סימון.</p>
+								<p>(Note that the <var>value</var> field in the example represents the text as it is
+									stored in memory, hence the discrepancy between it and the two renderings depicted
+									here.)</p>
 								<p>See also the [<cite><a class="bibref" data-link-type="biblio" href="#bib-string-meta"
 											title="Requirements for Language and Direction Metadata in Data Formats"
 											>string-meta</a></cite>] document for further explanations and examples.</p>

--- a/snapshot/index.html
+++ b/snapshot/index.html
@@ -1870,8 +1870,8 @@
 								<p dir="rtl">HTML היא שפת סימון.</p>
 								<p>Note that the <var>value</var> field in the example represents the text as it is
 									stored in memory, hence the discrepancy between it and the two renderings depicted
-									here. Text editors might also display the text differently (e.g., using the Unicode
-									Bidirectional Algorithm only).</p>
+									here. Text editors might also display the JSON value differently (e.g., using the
+									Unicode Bidirectional Algorithm only).</p>
 								<p>See also the [<cite><a class="bibref" data-link-type="biblio" href="#bib-string-meta"
 											title="Requirements for Language and Direction Metadata in Data Formats"
 											>string-meta</a></cite>] document for further explanations and examples.</p>

--- a/snapshot/index.html
+++ b/snapshot/index.html
@@ -1868,16 +1868,15 @@
 								<p>However, that would be incorrect. The extra <code>direction</code> value is necessary
 									to control the display to yield: </p>
 								<p dir="rtl">HTML היא שפת סימון.</p>
-								<p>(Note that the <var>value</var> field in the example represents the text as it is
+								<p>Note that the <var>value</var> field in the example represents the text as it is
 									stored in memory, hence the discrepancy between it and the two renderings depicted
-									here.)</p>
+									here. Text editors might also display the text differently (e.g., using the Unicode
+									Bidirectional Algorithm only).</p>
 								<p>See also the [<cite><a class="bibref" data-link-type="biblio" href="#bib-string-meta"
 											title="Requirements for Language and Direction Metadata in Data Formats"
 											>string-meta</a></cite>] document for further explanations and examples.</p>
 							</div>
 						</div>
-
-
 					</section>
 
 					<section id="value-entity">

--- a/snapshot/index.html
+++ b/snapshot/index.html
@@ -1456,8 +1456,8 @@
 					</dt>
 					<dd>
 						<p>Structural resources are key meta structures of the publication, such as the <a href="#cover"
-								>cover image</a>, <a href="#table-of-contents">table of contents</a>, and <a
-								href="#page-list">page list</a>.</p>
+								>cover image</a>, <a href="#contents">table of contents</a>, and <a href="#page-list"
+								>page list</a>.</p>
 					</dd>
 				</dl>
 			</section>
@@ -3975,8 +3975,8 @@
 							class="internalDFN" data-link-type="dfn" id="ref-for-dfn-links-1">links</a>, as defined in
 						this section. These lists contain references to <a href="#informative-rel">informative
 							resources</a> like the <a href="#privacy-policy">privacy policy</a>, and <a
-							href="#structural-rel">structural resources</a> like the <a href="#table-of-contents">table
-							of contents</a>.</p>
+							href="#structural-rel">structural resources</a> like the <a href="#contents">table of
+							contents</a>.</p>
 
 					<div class="note" role="note" id="issue-container-generatedID-16">
 						<div role="heading" class="note-title marker" id="h-note-16" aria-level="5">
@@ -7255,7 +7255,7 @@ enum TextDirection {
 					users.</p>
 
 				<p>The manifest <em class="rfc2119">SHOULD</em>
-					<a href="#table-of-contents">identify the resource</a> that contains the table of contents.</p>
+					<a href="#contents">identify the resource</a> that contains the table of contents.</p>
 
 				<p>Although the content model of the <code>nav</code> element is not restricted, user agents will only
 					be able to extract a usable table of contents when the following markup guidelines are followed:</p>

--- a/snapshot/index.html
+++ b/snapshot/index.html
@@ -499,7 +499,7 @@
 				publications, serialized in [json-ld11], to enable interoperability between publishing formats while
 				accommodating variances in the information that needs to be expressed." />
 		<link rel="canonical" href="https://www.w3.org/TR/pub-manifest/" />
-		<style type="text/css">
+		<style>
 			.hljs {
 				display: block;
 				overflow-x: auto;
@@ -794,6 +794,12 @@
       "id": "mfrel"
     }
   },
+  "alternateFormats": [
+    {
+      "uri": "pub-manifest.epub",
+      "label": "EPUB"
+    }
+  ],
   "publishDate": "2020-11-10",
   "publishISODate": "2020-11-10T00:00:00.000Z",
   "generatedSubtitle": "Recommendation 10 November 2020"
@@ -875,7 +881,9 @@
 				any errors or issues reported since publication. </p>
 			<p> See also <a href="http://www.w3.org/2003/03/Translations/byTechnology?technology=pub-manifest">
 					<strong>translations</strong></a>. </p>
-
+			<p> This document is also available in this non-normative format: <a rel="alternate"
+					href="pub-manifest.epub">EPUB</a>
+			</p>
 			<p class="copyright">
 				<a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2020 <a
 					href="https://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a
@@ -1859,14 +1867,14 @@
 								<span>Note</span>
 							</div>
 							<div class="">
-								<p>If the base direction value were not set in the last example, the text would be
+								<p> If the base direction value were not set in the last example, the text would be
 									displayed, following the Unicode Bidirectional Algorithm&#160;[<cite><a
 											class="bibref" data-link-type="biblio" href="#bib-bidi"
 											title="Unicode Bidirectional Algorithm">bidi</a></cite>] and due to the
 									presence of a Latin character starting the string, as: </p>
 								<p dir="ltr">HTML היא שפת סימון.</p>
-								<p>However, that would be incorrect. The extra <code>direction</code> value is necessary
-									to control the display to yield: </p>
+								<p> However, that would be incorrect. The extra <code>direction</code> value is
+									necessary to control the display to yield: </p>
 								<p dir="rtl">HTML היא שפת סימון.</p>
 								<p>Note that the <var>value</var> field in the example represents the text as it is
 									stored in memory, hence the discrepancy between it and the two renderings depicted
@@ -8919,7 +8927,7 @@ enum TextDirection {
 							>https://tools.ietf.org/html/rfc4627</a></dd>
 					<dt id="bib-json-ld11">[json-ld11]</dt>
 					<dd><a href="https://www.w3.org/TR/json-ld11/"><cite>JSON-LD 1.1</cite></a>. Gregg Kellogg;
-						Pierre-Antoine Champin; Dave Longley. W3C. 7 May 2020. W3C Proposed Recommendation. URL: <a
+						Pierre-Antoine Champin; Dave Longley. W3C. 16 July 2020. W3C Recommendation. URL: <a
 							href="https://www.w3.org/TR/json-ld11/">https://www.w3.org/TR/json-ld11/</a></dd>
 					<dt id="bib-mfrel">[mfrel]</dt>
 					<dd><a href="http://microformats.org/wiki/existing-rel-values#HTML5_link_type_extensions"
@@ -8974,7 +8982,7 @@ enum TextDirection {
 				<dl class="bibliography">
 					<dt id="bib-audiobooks">[audiobooks]</dt>
 					<dd><a href="https://www.w3.org/TR/audiobooks/"><cite>Audiobooks</cite></a>. Wendy Reid; Matt
-						Garrish. W3C. 17 March 2020. W3C Candidate Recommendation. URL: <a
+						Garrish. W3C. 10 November 2020. W3C Recommendation. URL: <a
 							href="https://www.w3.org/TR/audiobooks/">https://www.w3.org/TR/audiobooks/</a></dd>
 					<dt id="bib-ecma-404">[ecma-404]</dt>
 					<dd><a href="https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf"><cite>The


### PR DESCRIPTION
This fixes #244 by adding a parenthetical to the note to explain why the example text differs. It also adds the `bdo` tag to the REC snapshot to fix the rendering.

Note that the editor's draft will still strip the `bdo` tag, so to preview the fully-updated section, please see the snapshot: https://raw.githack.com/w3c/pub-manifest/editorial/text-dir/snapshot/index.html#example-2-set-the-language-and-the-base-direction-of-a-string

Let me know if the added para can use any improvement.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/245.html" title="Last updated on Nov 5, 2020, 1:37 PM UTC (fe3102c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/245/b5c50f7...fe3102c.html" title="Last updated on Nov 5, 2020, 1:37 PM UTC (fe3102c)">Diff</a>