### PR TITLE
Adding reading progression to schema

### DIFF
--- a/schema/module/progression.schema.json
+++ b/schema/module/progression.schema.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://www.w3.org/ns/pub-schema/manifest/module/progression.schema.json",
+	"title": "Progression direction",
+	"type": "string",
+	"enum": ["ltr", "rtl"],
+	"default": "ltr"
+}

--- a/schema/publication.schema.json
+++ b/schema/publication.schema.json
@@ -86,6 +86,9 @@
 		"readBy": {
 			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},
+		"readingProgression": {
+			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/progression.schema.json"
+		},
 		"translator": {
 			"$ref": "https://www.w3.org/ns/pub-schema/manifest/module/contributor.schema.json"
 		},


### PR DESCRIPTION
The term `readingProgression` was missing from the JSON Schema.

Fix #251

Cc: @MurakamiShinyu