### PR TITLE
Fix changed infra link to json parsing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2966,8 +2966,8 @@
 
 					<li id="processing-json-infra">
 						<p>Let <var>manifest</var> be the result of parsing <a
-								href="https://infra.spec.whatwg.org/#parse-json-into-infra-values">JSON into Infra
-								values</a> given <var>text</var>. If <var>manifest</var> is not a <a
+								href="https://infra.spec.whatwg.org/#parse-a-json-string-to-an-infra-value">JSON into
+								Infra values</a> given <var>text</var>. If <var>manifest</var> is not a <a
 								href="https://infra.spec.whatwg.org/#ordered-map">map</a>, <a>fatal error</a>, return
 							failure.</p>
 						<details>


### PR DESCRIPTION
Fixes the broken link issue reported in #255 and #247 

Fixes #247


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/pull/256.html" title="Last updated on Aug 4, 2023, 5:15 PM UTC (610133e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/pub-manifest/256/69eb16e...610133e.html" title="Last updated on Aug 4, 2023, 5:15 PM UTC (610133e)">Diff</a>