### PR TITLE
Update the respec structure to refer to the `main` branch instead of `master`

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 				wgPublicList: "public-pm-wg",
 				github: {
 					repoURL: "https://github.com/w3c/pub-manifest/",
-					branch: "master"
+					branch: "main"
 				},
 				localBiblio: localBiblio,
 				alternateFormats: [{


### PR DESCRIPTION
This is the counterpart of https://github.com/w3c/audiobooks/pull/119